### PR TITLE
Ingress: Add tests for various other ingress controllers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -25,9 +25,9 @@ testCase:
         skip: false
         reinstall: false 
         uninstall: true
-        # upgradeFromVersion: stable-2.7.0
+        upgradeFromVersion: stable-2.7.0
     inject:
-        skip: true
+        skip: false
         clean: true
     ingress:
         skip: false

--- a/config.yaml
+++ b/config.yaml
@@ -36,3 +36,4 @@ testCase:
                 - nginx
                 - traefik
                 - ambassador
+                - gloo

--- a/config.yaml
+++ b/config.yaml
@@ -34,3 +34,4 @@ testCase:
         config:
             controllers:
                 - nginx
+                - traefik

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 linkerdVersion: stable-2.8.0
 externalIssuer: false
 controlPlane:
-    # namespace: l5d-conformance
+    namespace: l5d-conformance
     config:   
         ha: false
         flags:
@@ -25,7 +25,7 @@ testCase:
         skip: false
         reinstall: false 
         uninstall: true
-        upgradeFromVersion: stable-2.7.0
+        # upgradeFromVersion: stable-2.7.0
     inject:
         skip: false
         clean: true
@@ -33,8 +33,18 @@ testCase:
         skip: false
         config:
             controllers:
-                - nginx
-                - ambassador
-                - traefik
-                - gloo
-                - contour
+                - name: nginx
+                  install: true
+                  clean: true
+                - name: ambassador
+                  install: true
+                  clean: true
+                - name: traefik
+                  install: true
+                  clean: true
+                - name: gloo
+                  install: true
+                  clean: true
+                - name: contour
+                  install: true
+                  clean: true

--- a/config.yaml
+++ b/config.yaml
@@ -25,9 +25,9 @@ testCase:
         skip: false
         reinstall: false 
         uninstall: true
-        upgradeFromVersion: stable-2.7.0
+        # upgradeFromVersion: stable-2.7.0
     inject:
-        skip: false
+        skip: true
         clean: true
     ingress:
         skip: false
@@ -35,3 +35,4 @@ testCase:
             controllers:
                 - nginx
                 - traefik
+                - ambassador

--- a/config.yaml
+++ b/config.yaml
@@ -34,6 +34,7 @@ testCase:
         config:
             controllers:
                 - nginx
-                - traefik
                 - ambassador
+                - traefik
                 - gloo
+                - contour

--- a/specs/ingress/spec.go
+++ b/specs/ingress/spec.go
@@ -7,50 +7,111 @@ import (
 	"github.com/onsi/ginkgo"
 )
 
+var (
+	nginx      = "nginx"
+	traefik    = "traefik"
+	ambassador = "ambassador"
+	gloo       = "gloo"
+	contour    = "contour"
+
+	nginxNs      = "ingress-nginx"
+	traefikNs    = "kube-system"
+	ambassadorNs = "ingress-ambassador"
+	glooNs       = "gloo-system"
+	contourNs    = "projectcontour"
+	kuardNs      = "default"
+
+	nginxController      = "ingress-nginx-controller"
+	traefikController    = "traefik-ingress-controller"
+	ambassadorController = "ambassador"
+	contourController    = "contour"
+	kuard                = "kuard"
+
+	kuardYAML = "https://projectcontour.io/examples/kuard.yaml"
+)
+
 type testRunner func()
 
 var testCases = []struct {
-	ingressType string
-	testRunner  testRunner
+	ingressName          string
+	controllerYAML       string
+	controllerDeployName string
+	controllerNs         string
+	testRunner           testRunner
 }{
 	{
-		ingressType: nginx,
-		testRunner:  testNginx,
+		ingressName:          nginx,
+		controllerYAML:       "testdata/ingress/controllers/nginx.yaml",
+		controllerDeployName: nginxController,
+		controllerNs:         nginxNs,
+		testRunner:           testNginx,
 	},
 	{
-		ingressType: traefik,
-		testRunner:  testTraefik,
+		ingressName:          traefik,
+		controllerYAML:       "testdata/ingress/controllers/traefik.yaml",
+		controllerDeployName: traefikController,
+		controllerNs:         traefikNs,
+		testRunner:           testTraefik,
 	},
 	{
-		ingressType: ambassador,
-		testRunner:  testAmbassador,
+		ingressName:          ambassador,
+		controllerYAML:       "testdata/ingress/controllers/ambassador.yaml",
+		controllerDeployName: ambassadorController,
+		controllerNs:         ambassadorNs,
+		testRunner:           testAmbassador,
 	},
 	{
-		ingressType: gloo,
-		testRunner:  testGloo,
+		ingressName:          gloo,
+		controllerYAML:       "", // `glooctl` is used for installation
+		controllerDeployName: "", // `glooctl` handles the checks
+		controllerNs:         glooNs,
+		testRunner:           testGloo,
 	},
 	{
-		ingressType: contour,
-		testRunner:  testContour,
+		ingressName:          contour,
+		controllerYAML:       "testdata/ingress/controllers/contour.yaml",
+		controllerDeployName: contourController,
+		controllerNs:         contourNs,
+		testRunner:           testContour,
 	},
-}
-
-func specMessage(controllerName string) string {
-	return fmt.Sprintf("can work with %s ingress controller", controllerName)
 }
 
 // RunIngressTests runs the specs for ingress
 func RunIngressTests() bool {
-	return ginkgo.Describe("ingress: ", func() {
+	return ginkgo.Describe("ingress", func() {
 		_, c := utils.GetHelperAndConfig()
 
 		_ = utils.ShouldTestSkip(c.SkipIngress(), "Skipping ingress tests")
 
 		for _, tc := range testCases {
 			tc := tc //pin
-			if c.ShouldTestIngressOfType(tc.ingressType) {
-				ginkgo.It(specMessage(tc.ingressType), func() {
-					tc.testRunner()
+			if c.ShouldTestIngressOfType(tc.ingressName) {
+				ginkgo.Context(fmt.Sprintf("%s:", tc.ingressName), func() {
+					ginkgo.It("sample application can be installed", func() {
+						testSampleAppInstall(tc.ingressName)
+					})
+
+					ginkgo.It(fmt.Sprintf("%s ingress controller must work with Linkerd", tc.ingressName), func() {
+						if c.ShouldInstallIngressOfType(tc.ingressName) {
+							testControllerInstall(tc.ingressName,
+								tc.controllerYAML,
+								tc.controllerDeployName,
+								tc.controllerNs)
+						}
+
+						tc.testRunner() // run main body of the test
+					})
+
+					if c.ShouldCleanIngressInstallation(tc.ingressName) {
+
+						ginkgo.It("sample application can be uninstalled", func() {
+							testSampleAppUninstall(tc.ingressName)
+						})
+
+						ginkgo.It("controller can be uninstalled", func() {
+							testControllerUninstall(tc.ingressName, tc.controllerYAML, tc.controllerNs)
+						})
+					}
 				})
 			}
 		}

--- a/specs/ingress/spec.go
+++ b/specs/ingress/spec.go
@@ -1,9 +1,15 @@
 package ingress
 
 import (
+	"fmt"
+
 	"github.com/linkerd/linkerd2-conformance/utils"
 	"github.com/onsi/ginkgo"
 )
+
+func specMessage(controllerName string) string {
+	return fmt.Sprintf("can work with %s ingress controller", controllerName)
+}
 
 // RunIngressTests runs the specs for ingress
 func RunIngressTests() bool {
@@ -12,13 +18,12 @@ func RunIngressTests() bool {
 
 		_ = utils.ShouldTestSkip(c.SkipIngress(), "Skipping ingress tests")
 
-		ginkgo.It("can install and inject emojivoto app", func() {
-			utils.TestEmojivotoApp()
-			utils.TestEmojivotoInject()
-		})
+		if c.ShouldTestIngressOfType(nginx) {
+			ginkgo.It(specMessage(nginx), testNginx)
+		}
 
-		if c.ShouldTestIngressOfType(utils.Nginx) {
-			ginkgo.It("can work with nginx ingress controller", testNginx)
+		if c.ShouldTestIngressOfType(traefik) {
+			ginkgo.It(specMessage(traefik), testTraefik)
 		}
 
 		ginkgo.It("can uninstall emojivoto app", utils.TestEmojivotoUninstall)

--- a/specs/ingress/spec.go
+++ b/specs/ingress/spec.go
@@ -29,6 +29,10 @@ var testCases = []struct {
 		ingressType: gloo,
 		testRunner:  testGloo,
 	},
+	{
+		ingressType: contour,
+		testRunner:  testContour,
+	},
 }
 
 func specMessage(controllerName string) string {

--- a/specs/ingress/spec.go
+++ b/specs/ingress/spec.go
@@ -46,7 +46,5 @@ func RunIngressTests() bool {
 				})
 			}
 		}
-
-		ginkgo.It("can uninstall emojivoto app", utils.TestEmojivotoUninstall)
 	})
 }

--- a/specs/ingress/spec.go
+++ b/specs/ingress/spec.go
@@ -25,6 +25,10 @@ var testCases = []struct {
 		ingressType: ambassador,
 		testRunner:  testAmbassador,
 	},
+	{
+		ingressType: gloo,
+		testRunner:  testGloo,
+	},
 }
 
 func specMessage(controllerName string) string {

--- a/specs/ingress/tests.go
+++ b/specs/ingress/tests.go
@@ -119,7 +119,7 @@ func testIngress(ingressName, deploy, ns, controllerYAMLPath, resourceYAMLPath s
 
 	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to reach emojivoto: %s", utils.Err(err)))
 
-	ginkgo.By(fmt.Sprintf("Removing %s ingress controller", ns))
+	ginkgo.By(fmt.Sprintf("Removing %s ingress controller", ingressName))
 
 	_, err = h.Kubectl("", "delete", "-f", controllerYAMLPath)
 	gomega.Expect(err).Should(gomega.BeNil(), utils.Err(err))

--- a/specs/ingress/tests.go
+++ b/specs/ingress/tests.go
@@ -12,14 +12,17 @@ import (
 )
 
 var (
-	nginx   = "nginx"
-	traefik = "traefik"
+	nginx      = "nginx"
+	traefik    = "traefik"
+	ambassador = "ambassador"
 
-	nginxNs   = "ingress-nginx"
-	traefikNs = "kube-system"
+	nginxNs      = "ingress-nginx"
+	traefikNs    = "kube-system"
+	ambassadorNs = "ingress-ambassador"
 
-	nginxController   = "ingress-nginx-controller"
-	traefikController = "traefik-ingress-controller"
+	nginxController      = "ingress-nginx-controller"
+	traefikController    = "traefik-ingress-controller"
+	ambassadorController = "ambassador"
 )
 
 func pingEmojivoto(ip string) error {
@@ -121,7 +124,6 @@ func testIngress(ingressName, deploy, ns, controllerYAMLPath, resourceYAMLPath s
 	_, err = h.Kubectl("", "delete", "-f", controllerYAMLPath)
 	gomega.Expect(err).Should(gomega.BeNil(), utils.Err(err))
 
-	ginkgo.By("Uninstalling emojivoto")
 	utils.TestEmojivotoUninstall()
 }
 
@@ -139,4 +141,12 @@ func testTraefik() {
 		traefikResourceYAML   = "testdata/ingress/resources/traefik.yaml"
 	)
 	testIngress(traefik, traefikController, traefikNs, traefikControllerYAML, traefikResourceYAML)
+}
+
+func testAmbassador() {
+	var (
+		ambassadorControllerYAML = "testdata/ingress/controllers/ambassador.yaml"
+		ambassadorResourceYAML   = "testdata/ingress/resources/ambassador.yaml"
+	)
+	testIngress(ambassador, ambassadorController, ambassadorNs, ambassadorControllerYAML, ambassadorResourceYAML)
 }

--- a/specs/ingress/tests.go
+++ b/specs/ingress/tests.go
@@ -15,18 +15,20 @@ var (
 	nginx      = "nginx"
 	traefik    = "traefik"
 	ambassador = "ambassador"
+	gloo       = "gloo"
 
 	nginxNs      = "ingress-nginx"
 	traefikNs    = "kube-system"
 	ambassadorNs = "ingress-ambassador"
+	glooNs       = "gloo-system"
 
 	nginxController      = "ingress-nginx-controller"
 	traefikController    = "traefik-ingress-controller"
 	ambassadorController = "ambassador"
 )
 
-func pingEmojivoto(ip string) error {
-	req, err := http.NewRequest("GET", fmt.Sprintf("http://%s", ip), nil)
+func pingIP(ip string) error {
+	req, err := http.NewRequest("GET", ip, nil)
 	if err != nil {
 		return err
 	}
@@ -34,7 +36,7 @@ func pingEmojivoto(ip string) error {
 	req.Host = "example.com"
 
 	client := http.Client{
-		Timeout: 3 * time.Minute,
+		Timeout: 15 * time.Minute,
 	}
 
 	res, err := client.Do(req)
@@ -114,7 +116,7 @@ func testIngress(ingressName, deploy, ns, controllerYAMLPath, resourceYAMLPath s
 	gomega.Expect(err).Should(gomega.BeNil(), utils.Err(err))
 
 	err = h.RetryFor(3*time.Minute, func() error {
-		return pingEmojivoto(strings.Trim(ip, "'"))
+		return pingIP(fmt.Sprintf("http://%s", strings.Trim(ip, "'")))
 	})
 
 	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to reach emojivoto: %s", utils.Err(err)))
@@ -149,4 +151,52 @@ func testAmbassador() {
 		ambassadorResourceYAML   = "testdata/ingress/resources/ambassador.yaml"
 	)
 	testIngress(ambassador, ambassadorController, ambassadorNs, ambassadorControllerYAML, ambassadorResourceYAML)
+}
+
+func testGloo() {
+	h, _ := utils.GetHelperAndConfig()
+
+	ginkgo.By("Install `glooctl` binary")
+	err := utils.InstallGlooctlBinary()
+	gomega.Expect(err).Should(gomega.BeNil(), utils.Err(err))
+
+	ginkgo.By("Install Gloo ingress controller")
+	_, err = utils.GlooctlRun("install", "gateway")
+	gomega.Expect(err).Should(gomega.BeNil(), utils.Err(err))
+
+	// Install and inject booksapp
+	utils.TestBooksappApp()
+	utils.TestBooksappInject()
+
+	ginkgo.By("Enabling native integration with Linkerd")
+	_, err = h.Kubectl("", "patch", "settings", "-n", glooNs, "default", "-p", "{\"spec\":{\"linkerd\":true}}", "--type", "merge")
+	gomega.Expect(err).Should(gomega.BeNil(), utils.Err(err))
+
+	ginkgo.By("Adding booksapp route to the virtual service")
+	_, err = utils.GlooctlRun("add", "route", "--path-prefix", "/", "--dest-name", "booksapp-webapp-7000")
+	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to add booksapp route to virtual service: %s", utils.Err(err)))
+
+	ginkgo.By("Checking if booksapp is reachable")
+
+	err = h.RetryFor(time.Minute*5, func() error {
+		ip, err := utils.GlooctlRun("proxy", "url")
+		if err != nil {
+			return fmt.Errorf("failed to fetch external IP: %s", err.Error())
+		}
+
+		err = pingIP(strings.Trim(ip, "'"))
+		if err != nil {
+			return fmt.Errorf("sample application booksapp is not reachable")
+		}
+		return nil
+	})
+
+	ginkgo.By("Uninstalling gloo ingress controller")
+	_, err = utils.GlooctlRun("uninstall", "gateway")
+	gomega.Expect(err).Should(gomega.BeNil(), utils.Err(err))
+	_, err = h.Kubectl("", "delete", "ns", glooNs)
+	gomega.Expect(err).Should(gomega.BeNil(), utils.Err(err))
+
+	// Uninstall booksapp
+	utils.TestBooksappUninstall()
 }

--- a/testdata/booksapp.yaml
+++ b/testdata/booksapp.yaml
@@ -1,0 +1,197 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: booksapp
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: webapp
+  labels:
+    app: webapp
+    project: booksapp
+spec:
+  selector:
+    app: webapp
+  type: ClusterIP
+  ports:
+  - name: service
+    port: 7000
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: webapp
+  labels:
+    app: webapp
+    project: booksapp
+    app.kubernetes.io/part-of: booksapp
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: webapp
+      project: booksapp
+  template:
+    metadata:
+      labels:
+        app: webapp
+        project: booksapp
+    spec:
+      dnsPolicy: ClusterFirst
+      containers:
+      - name: service
+        image: buoyantio/booksapp:v0.0.5
+        env:
+        - name: DATABASE_URL
+          value: sqlite3:db/db.sqlite3
+        - name: AUTHORS_SITE
+          value: http://authors:7001
+        - name: BOOKS_SITE
+          value: http://books:7002
+        args: ["prod:webapp"]
+        readinessProbe:
+          httpGet:
+            path: /ping
+            port: 7000
+        ports:
+        - name: service
+          containerPort: 7000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: authors
+  labels:
+    app: authors
+    project: booksapp
+spec:
+  selector:
+    app: authors
+  clusterIP: None
+  ports:
+  - name: service
+    port: 7001
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: authors
+  labels:
+    app: authors
+    project: booksapp
+    app.kubernetes.io/part-of: booksapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: authors
+      project: booksapp
+  template:
+    metadata:
+      labels:
+        app: authors
+        project: booksapp
+    spec:
+      dnsPolicy: ClusterFirst
+      containers:
+      - name: service
+        image: buoyantio/booksapp:v0.0.5
+        env:
+        - name: DATABASE_URL
+          value: sqlite3:db/db.sqlite3
+        - name: BOOKS_SITE
+          value: http://books:7002
+        - name: FAILURE_RATE
+          value: "0.5"
+        args: ["prod:authors"]
+        readinessProbe:
+          httpGet:
+            path: /ping
+            port: 7001
+        ports:
+        - name: service
+          containerPort: 7001
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: books
+  labels:
+    app: books
+    project: booksapp
+spec:
+  selector:
+    app: books
+  clusterIP: None
+  ports:
+  - name: service
+    port: 7002
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: books
+  labels:
+    app: books
+    project: booksapp
+    app.kubernetes.io/part-of: booksapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: books
+      project: booksapp
+  template:
+    metadata:
+      labels:
+        app: books
+        project: booksapp
+    spec:
+      dnsPolicy: ClusterFirst
+      containers:
+      - name: service
+        image: buoyantio/booksapp:v0.0.5
+        env:
+        - name: DATABASE_URL
+          value: sqlite3:db/db.sqlite3
+        - name: AUTHORS_SITE
+          value: http://authors:7001
+        args: ["prod:books"]
+        readinessProbe:
+          httpGet:
+            path: /ping
+            port: 7002
+        ports:
+        - name: service
+          containerPort: 7002
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: traffic
+  labels:
+    app: traffic
+    project: booksapp
+    app.kubernetes.io/part-of: booksapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: traffic
+      project: booksapp
+  template:
+    metadata:
+      labels:
+        app: traffic
+        project: booksapp
+    spec:
+      dnsPolicy: ClusterFirst
+      containers:
+      - name: traffic
+        image: buoyantio/booksapp-traffic:v0.0.3
+        args:
+        - "-initial-delay=30s"
+        - "webapp:7000"
+

--- a/testdata/ingress/controllers/ambassador.yaml
+++ b/testdata/ingress/controllers/ambassador.yaml
@@ -1,0 +1,160 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ingress-ambassador
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: ambassador
+    app.kubernetes.io/managed-by: getambassador.io
+  name: ambassador
+  namespace: ingress-ambassador
+spec:
+  type: LoadBalancer
+  ports:
+  - name: ambassador-admin
+    port: 8877
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: http
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: https
+  selector:
+    service: ambassador
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: ambassador
+  namespace: ingress-ambassador
+rules:
+- apiGroups: [""]
+  resources: [ "endpoints", "namespaces", "secrets", "services" ]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [ "getambassador.io" ]
+  resources: [ "*" ]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [ "getambassador.io" ]
+  resources: [ "mappings/status" ]
+  verbs: ["update"]
+- apiGroups: [ "apiextensions.k8s.io" ]
+  resources: [ "customresourcedefinitions" ]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [ "networking.internal.knative.dev" ]
+  resources: [ "clusteringresses", "ingresses" ]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [ "networking.internal.knative.dev" ]
+  resources: [ "ingresses/status", "clusteringresses/status" ]
+  verbs: ["update"]
+- apiGroups: [ "extensions", "networking.k8s.io" ]
+  resources: [ "ingresses", "ingressclasses" ]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [ "extensions", "networking.k8s.io" ]
+  resources: [ "ingresses/status" ]
+  verbs: ["update"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ambassador
+  namespace: ingress-ambassador
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: ambassador
+  namespace: ingress-ambassador
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ambassador
+subjects:
+- kind: ServiceAccount
+  name: ambassador
+  namespace: ingress-ambassador
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ambassador
+  namespace: ingress-ambassador
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: ambassador
+  template:
+    metadata:
+      annotations:
+        consul.hashicorp.com/connect-inject: 'false'
+        sidecar.istio.io/inject: 'false'
+      labels:
+        service: ambassador
+        app.kubernetes.io/managed-by: getambassador.io
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  service: ambassador
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      containers:
+      - env:
+        - name: AMBASSADOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.io/datawire/ambassador:1.6.0
+        livenessProbe:
+          httpGet:
+            path: /ambassador/v0/check_alive
+            port: 8877
+          initialDelaySeconds: 30
+          periodSeconds: 3
+        name: ambassador
+        ports:
+        - containerPort: 8080
+          name: http
+        - containerPort: 8443
+          name: https
+        - containerPort: 8877
+          name: admin
+        readinessProbe:
+          httpGet:
+            path: /ambassador/v0/check_ready
+            port: 8877
+          initialDelaySeconds: 30
+          periodSeconds: 3
+        resources:
+          limits:
+            cpu: 1
+            memory: 400Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - mountPath: /tmp/ambassador-pod-info
+          name: ambassador-pod-info
+      restartPolicy: Always
+      securityContext:
+        runAsUser: 8888
+      serviceAccountName: ambassador
+      volumes:
+      - downwardAPI:
+          items:
+          - fieldRef:
+              fieldPath: metadata.labels
+            path: labels
+        name: ambassador-pod-info
+

--- a/testdata/ingress/controllers/contour.yaml
+++ b/testdata/ingress/controllers/contour.yaml
@@ -1,0 +1,1436 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    linkerd.io/inject: enabled
+  name: projectcontour
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: contour
+  namespace: projectcontour
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: envoy
+  namespace: projectcontour
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: contour
+  namespace: projectcontour
+data:
+  contour.yaml: |
+    # should contour expect to be running inside a k8s cluster
+    # incluster: true
+    #
+    # path to kubeconfig (if not running inside a k8s cluster)
+    # kubeconfig: /path/to/.kube/config
+    #
+    # Client request timeout to be passed to Envoy
+    # as the connection manager request_timeout.
+    # Defaults to 0, which Envoy interprets as disabled.
+    # Note that this is the timeout for the whole request,
+    # not an idle timeout.
+    # request-timeout: 0s
+    # disable HTTPProxy permitInsecure field
+    disablePermitInsecure: false
+    tls:
+    # minimum TLS version that Contour will negotiate
+    # minimum-protocol-version: "1.1"
+    # Defines the Kubernetes name/namespace matching a secret to use
+    # as the fallback certificate when requests which don't match the
+    # SNI defined for a vhost.
+      fallback-certificate:
+    #   name: fallback-secret-name
+    #   namespace: projectcontour
+    # The following config shows the defaults for the leader election.
+    # leaderelection:
+    #   configmap-name: leader-elect
+    #   configmap-namespace: projectcontour
+    ### Logging options
+    # Default setting
+    accesslog-format: envoy
+    # To enable JSON logging in Envoy
+    # accesslog-format: json
+    # The default fields that will be logged are specified below.
+    # To customise this list, just add or remove entries.
+    # The canonical list is available at
+    # https://godoc.org/github.com/projectcontour/contour/internal/envoy#JSONFields
+    # json-fields:
+    #   - "@timestamp"
+    #   - "authority"
+    #   - "bytes_received"
+    #   - "bytes_sent"
+    #   - "downstream_local_address"
+    #   - "downstream_remote_address"
+    #   - "duration"
+    #   - "method"
+    #   - "path"
+    #   - "protocol"
+    #   - "request_id"
+    #   - "requested_server_name"
+    #   - "response_code"
+    #   - "response_flags"
+    #   - "uber_trace_id"
+    #   - "upstream_cluster"
+    #   - "upstream_host"
+    #   - "upstream_local_address"
+    #   - "upstream_service_time"
+    #   - "user_agent"
+    #   - "x_forwarded_for"
+    #
+    # default-http-versions:
+    # - "HTTP/2"
+    # - "HTTP/1.1"
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: httpproxies.projectcontour.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.virtualhost.fqdn
+    description: Fully qualified domain name
+    name: FQDN
+    type: string
+  - JSONPath: .spec.virtualhost.tls.secretName
+    description: Secret with TLS credentials
+    name: TLS Secret
+    type: string
+  - JSONPath: .status.currentStatus
+    description: The current status of the HTTPProxy
+    name: Status
+    type: string
+  - JSONPath: .status.description
+    description: Description of the current status
+    name: Status Description
+    type: string
+  group: projectcontour.io
+  names:
+    kind: HTTPProxy
+    listKind: HTTPProxyList
+    plural: httpproxies
+    shortNames:
+    - proxy
+    - proxies
+    singular: httpproxy
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: HTTPProxy is an Ingress CRD specification
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: HTTPProxySpec defines the spec of the CRD.
+          properties:
+            includes:
+              description: Includes allow for specific routing configuration to be
+                appended to another HTTPProxy in another namespace.
+              items:
+                description: Include describes a set of policies that can be applied
+                  to an HTTPProxy in a namespace.
+                properties:
+                  conditions:
+                    description: Conditions are a set of routing properties that is
+                      applied to an HTTPProxy in a namespace.
+                    items:
+                      description: Condition are policies that are applied on top
+                        of HTTPProxies. One of Prefix or Header must be provided.
+                      properties:
+                        header:
+                          description: Header specifies the header condition to match.
+                          properties:
+                            contains:
+                              description: Contains specifies a substring that must
+                                be present in the header value.
+                              type: string
+                            exact:
+                              description: Exact specifies a string that the header
+                                value must be equal to.
+                              type: string
+                            name:
+                              description: Name is the name of the header to match
+                                against. Name is required. Header names are case insensitive.
+                              type: string
+                            notcontains:
+                              description: NotContains specifies a substring that
+                                must not be present in the header value.
+                              type: string
+                            notexact:
+                              description: NoExact specifies a string that the header
+                                value must not be equal to. The condition is true
+                                if the header has any other value.
+                              type: string
+                            present:
+                              description: Present specifies that condition is true
+                                when the named header is present, regardless of its
+                                value. Note that setting Present to false does not
+                                make the condition true if the named header is absent.
+                              type: boolean
+                          required:
+                          - name
+                          type: object
+                        prefix:
+                          description: Prefix defines a prefix match for a request.
+                          type: string
+                      type: object
+                    type: array
+                  name:
+                    description: Name of the HTTPProxy
+                    type: string
+                  namespace:
+                    description: Namespace of the HTTPProxy to include. Defaults to
+                      the current namespace if not supplied.
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            routes:
+              description: Routes are the ingress routes. If TCPProxy is present,
+                Routes is ignored.
+              items:
+                description: Route contains the set of routes for a virtual host.
+                properties:
+                  conditions:
+                    description: Conditions are a set of routing properties that is
+                      applied to an HTTPProxy in a namespace.
+                    items:
+                      description: Condition are policies that are applied on top
+                        of HTTPProxies. One of Prefix or Header must be provided.
+                      properties:
+                        header:
+                          description: Header specifies the header condition to match.
+                          properties:
+                            contains:
+                              description: Contains specifies a substring that must
+                                be present in the header value.
+                              type: string
+                            exact:
+                              description: Exact specifies a string that the header
+                                value must be equal to.
+                              type: string
+                            name:
+                              description: Name is the name of the header to match
+                                against. Name is required. Header names are case insensitive.
+                              type: string
+                            notcontains:
+                              description: NotContains specifies a substring that
+                                must not be present in the header value.
+                              type: string
+                            notexact:
+                              description: NoExact specifies a string that the header
+                                value must not be equal to. The condition is true
+                                if the header has any other value.
+                              type: string
+                            present:
+                              description: Present specifies that condition is true
+                                when the named header is present, regardless of its
+                                value. Note that setting Present to false does not
+                                make the condition true if the named header is absent.
+                              type: boolean
+                          required:
+                          - name
+                          type: object
+                        prefix:
+                          description: Prefix defines a prefix match for a request.
+                          type: string
+                      type: object
+                    type: array
+                  enableWebsockets:
+                    description: Enables websocket support for the route.
+                    type: boolean
+                  healthCheckPolicy:
+                    description: The health check policy for this route.
+                    properties:
+                      healthyThresholdCount:
+                        description: The number of healthy health checks required
+                          before a host is marked healthy
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      host:
+                        description: The value of the host header in the HTTP health
+                          check request. If left empty (default value), the name "contour-envoy-healthcheck"
+                          will be used.
+                        type: string
+                      intervalSeconds:
+                        description: The interval (seconds) between health checks
+                        format: int64
+                        type: integer
+                      path:
+                        description: HTTP endpoint used to perform health checks on
+                          upstream service
+                        type: string
+                      timeoutSeconds:
+                        description: The time to wait (seconds) for a health check
+                          response
+                        format: int64
+                        type: integer
+                      unhealthyThresholdCount:
+                        description: The number of unhealthy health checks required
+                          before a host is marked unhealthy
+                        format: int64
+                        minimum: 0
+                        type: integer
+                    required:
+                    - path
+                    type: object
+                  loadBalancerPolicy:
+                    description: The load balancing policy for this route.
+                    properties:
+                      strategy:
+                        description: Strategy specifies the policy used to balance
+                          requests across the pool of backend pods. Valid policy names
+                          are `Random`, `RoundRobin`, `WeightedLeastRequest`, `Random`
+                          and `Cookie`. If an unknown strategy name is specified or
+                          no policy is supplied, the default `RoundRobin` policy is
+                          used.
+                        type: string
+                    type: object
+                  pathRewritePolicy:
+                    description: The policy for rewriting the path of the request
+                      URL after the request has been routed to a Service.
+                    properties:
+                      replacePrefix:
+                        description: ReplacePrefix describes how the path prefix should
+                          be replaced.
+                        items:
+                          description: ReplacePrefix describes a path prefix replacement.
+                          properties:
+                            prefix:
+                              description: "Prefix specifies the URL path prefix to
+                                be replaced. \n If Prefix is specified, it must exactly
+                                match the Condition prefix that is rendered by the
+                                chain of including HTTPProxies and only that path
+                                prefix will be replaced by Replacement. This allows
+                                HTTPProxies that are included through multiple roots
+                                to only replace specific path prefixes, leaving others
+                                unmodified. \n If Prefix is not specified, all routing
+                                prefixes rendered by the include chain will be replaced."
+                              minLength: 1
+                              type: string
+                            replacement:
+                              description: Replacement is the string that the routing
+                                path prefix will be replaced with. This must not be
+                                empty.
+                              minLength: 1
+                              type: string
+                          required:
+                          - replacement
+                          type: object
+                        type: array
+                    type: object
+                  permitInsecure:
+                    description: Allow this path to respond to insecure requests over
+                      HTTP which are normally not permitted when a `virtualhost.tls`
+                      block is present.
+                    type: boolean
+                  requestHeadersPolicy:
+                    description: The policy for managing request headers during proxying
+                    properties:
+                      remove:
+                        description: Remove specifies a list of HTTP header names
+                          to remove.
+                        items:
+                          type: string
+                        type: array
+                      set:
+                        description: Set specifies a list of HTTP header values that
+                          will be set in the HTTP header. If the header does not exist
+                          it will be added, otherwise it will be overwritten with
+                          the new value.
+                        items:
+                          description: HeaderValue represents a header name/value
+                            pair
+                          properties:
+                            name:
+                              description: Name represents a key of a header
+                              minLength: 1
+                              type: string
+                            value:
+                              description: Value represents the value of a header
+                                specified by a key
+                              minLength: 1
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                    type: object
+                  responseHeadersPolicy:
+                    description: The policy for managing response headers during proxying
+                    properties:
+                      remove:
+                        description: Remove specifies a list of HTTP header names
+                          to remove.
+                        items:
+                          type: string
+                        type: array
+                      set:
+                        description: Set specifies a list of HTTP header values that
+                          will be set in the HTTP header. If the header does not exist
+                          it will be added, otherwise it will be overwritten with
+                          the new value.
+                        items:
+                          description: HeaderValue represents a header name/value
+                            pair
+                          properties:
+                            name:
+                              description: Name represents a key of a header
+                              minLength: 1
+                              type: string
+                            value:
+                              description: Value represents the value of a header
+                                specified by a key
+                              minLength: 1
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                    type: object
+                  retryPolicy:
+                    description: The retry policy for this route.
+                    properties:
+                      count:
+                        description: NumRetries is maximum allowed number of retries.
+                          If not supplied, the number of retries is one.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      perTryTimeout:
+                        description: PerTryTimeout specifies the timeout per retry
+                          attempt. Ignored if NumRetries is not supplied.
+                        type: string
+                    type: object
+                  services:
+                    description: Services are the services to proxy traffic.
+                    items:
+                      description: Service defines an Kubernetes Service to proxy
+                        traffic.
+                      properties:
+                        mirror:
+                          description: If Mirror is true the Service will receive
+                            a read only mirror of the traffic for this route.
+                          type: boolean
+                        name:
+                          description: Name is the name of Kubernetes service to proxy
+                            traffic. Names defined here will be used to look up corresponding
+                            endpoints which contain the ips to route.
+                          type: string
+                        port:
+                          description: Port (defined as Integer) to proxy traffic
+                            to since a service can have multiple defined.
+                          exclusiveMaximum: true
+                          maximum: 65536
+                          minimum: 1
+                          type: integer
+                        protocol:
+                          description: Protocol may be used to specify (or override)
+                            the protocol used to reach this Service. Values may be
+                            tls, h2, h2c. If omitted, protocol-selection falls back
+                            on Service annotations.
+                          enum:
+                          - h2
+                          - h2c
+                          - tls
+                          type: string
+                        requestHeadersPolicy:
+                          description: The policy for managing request headers during
+                            proxying
+                          properties:
+                            remove:
+                              description: Remove specifies a list of HTTP header
+                                names to remove.
+                              items:
+                                type: string
+                              type: array
+                            set:
+                              description: Set specifies a list of HTTP header values
+                                that will be set in the HTTP header. If the header
+                                does not exist it will be added, otherwise it will
+                                be overwritten with the new value.
+                              items:
+                                description: HeaderValue represents a header name/value
+                                  pair
+                                properties:
+                                  name:
+                                    description: Name represents a key of a header
+                                    minLength: 1
+                                    type: string
+                                  value:
+                                    description: Value represents the value of a header
+                                      specified by a key
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                          type: object
+                        responseHeadersPolicy:
+                          description: The policy for managing response headers during
+                            proxying
+                          properties:
+                            remove:
+                              description: Remove specifies a list of HTTP header
+                                names to remove.
+                              items:
+                                type: string
+                              type: array
+                            set:
+                              description: Set specifies a list of HTTP header values
+                                that will be set in the HTTP header. If the header
+                                does not exist it will be added, otherwise it will
+                                be overwritten with the new value.
+                              items:
+                                description: HeaderValue represents a header name/value
+                                  pair
+                                properties:
+                                  name:
+                                    description: Name represents a key of a header
+                                    minLength: 1
+                                    type: string
+                                  value:
+                                    description: Value represents the value of a header
+                                      specified by a key
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                          type: object
+                        validation:
+                          description: UpstreamValidation defines how to verify the
+                            backend service's certificate
+                          properties:
+                            caSecret:
+                              description: Name of the Kubernetes secret be used to
+                                validate the certificate presented by the backend
+                              type: string
+                            subjectName:
+                              description: Key which is expected to be present in
+                                the 'subjectAltName' of the presented certificate
+                              type: string
+                          required:
+                          - caSecret
+                          - subjectName
+                          type: object
+                        weight:
+                          description: Weight defines percentage of traffic to balance
+                            traffic
+                          format: int64
+                          minimum: 0
+                          type: integer
+                      required:
+                      - name
+                      - port
+                      type: object
+                    minItems: 1
+                    type: array
+                  timeoutPolicy:
+                    description: The timeout policy for this route.
+                    properties:
+                      idle:
+                        description: Timeout after which, if there are no active requests
+                          for this route, the connection between Envoy and the backend
+                          or Envoy and the external client will be closed. If not
+                          specified, there is no per-route idle timeout, though a
+                          connection manager-wide stream_idle_timeout default of 5m
+                          still applies.
+                        type: string
+                      response:
+                        description: Timeout for receiving a response from the server
+                          after processing a request from client. If not supplied,
+                          Envoy's default value of 15s applies.
+                        type: string
+                    type: object
+                required:
+                - services
+                type: object
+              type: array
+            tcpproxy:
+              description: TCPProxy holds TCP proxy information.
+              properties:
+                healthCheckPolicy:
+                  description: The health check policy for this tcp proxy
+                  properties:
+                    healthyThresholdCount:
+                      description: The number of healthy health checks required before
+                        a host is marked healthy
+                      format: int32
+                      type: integer
+                    intervalSeconds:
+                      description: The interval (seconds) between health checks
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: The time to wait (seconds) for a health check response
+                      format: int64
+                      type: integer
+                    unhealthyThresholdCount:
+                      description: The number of unhealthy health checks required
+                        before a host is marked unhealthy
+                      format: int32
+                      type: integer
+                  type: object
+                include:
+                  description: Include specifies that this tcpproxy should be delegated
+                    to another HTTPProxy.
+                  properties:
+                    name:
+                      description: Name of the child HTTPProxy
+                      type: string
+                    namespace:
+                      description: Namespace of the HTTPProxy to include. Defaults
+                        to the current namespace if not supplied.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                includes:
+                  description: "IncludesDeprecated allow for specific routing configuration
+                    to be appended to another HTTPProxy in another namespace. \n Exists
+                    due to a mistake when developing HTTPProxy and the field was marked
+                    plural when it should have been singular. This field should stay
+                    to not break backwards compatibility to v1 users."
+                  properties:
+                    name:
+                      description: Name of the child HTTPProxy
+                      type: string
+                    namespace:
+                      description: Namespace of the HTTPProxy to include. Defaults
+                        to the current namespace if not supplied.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                loadBalancerPolicy:
+                  description: The load balancing policy for the backend services.
+                  properties:
+                    strategy:
+                      description: Strategy specifies the policy used to balance requests
+                        across the pool of backend pods. Valid policy names are `Random`,
+                        `RoundRobin`, `WeightedLeastRequest`, `Random` and `Cookie`.
+                        If an unknown strategy name is specified or no policy is supplied,
+                        the default `RoundRobin` policy is used.
+                      type: string
+                  type: object
+                services:
+                  description: Services are the services to proxy traffic
+                  items:
+                    description: Service defines an Kubernetes Service to proxy traffic.
+                    properties:
+                      mirror:
+                        description: If Mirror is true the Service will receive a
+                          read only mirror of the traffic for this route.
+                        type: boolean
+                      name:
+                        description: Name is the name of Kubernetes service to proxy
+                          traffic. Names defined here will be used to look up corresponding
+                          endpoints which contain the ips to route.
+                        type: string
+                      port:
+                        description: Port (defined as Integer) to proxy traffic to
+                          since a service can have multiple defined.
+                        exclusiveMaximum: true
+                        maximum: 65536
+                        minimum: 1
+                        type: integer
+                      protocol:
+                        description: Protocol may be used to specify (or override)
+                          the protocol used to reach this Service. Values may be tls,
+                          h2, h2c. If omitted, protocol-selection falls back on Service
+                          annotations.
+                        enum:
+                        - h2
+                        - h2c
+                        - tls
+                        type: string
+                      requestHeadersPolicy:
+                        description: The policy for managing request headers during
+                          proxying
+                        properties:
+                          remove:
+                            description: Remove specifies a list of HTTP header names
+                              to remove.
+                            items:
+                              type: string
+                            type: array
+                          set:
+                            description: Set specifies a list of HTTP header values
+                              that will be set in the HTTP header. If the header does
+                              not exist it will be added, otherwise it will be overwritten
+                              with the new value.
+                            items:
+                              description: HeaderValue represents a header name/value
+                                pair
+                              properties:
+                                name:
+                                  description: Name represents a key of a header
+                                  minLength: 1
+                                  type: string
+                                value:
+                                  description: Value represents the value of a header
+                                    specified by a key
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                        type: object
+                      responseHeadersPolicy:
+                        description: The policy for managing response headers during
+                          proxying
+                        properties:
+                          remove:
+                            description: Remove specifies a list of HTTP header names
+                              to remove.
+                            items:
+                              type: string
+                            type: array
+                          set:
+                            description: Set specifies a list of HTTP header values
+                              that will be set in the HTTP header. If the header does
+                              not exist it will be added, otherwise it will be overwritten
+                              with the new value.
+                            items:
+                              description: HeaderValue represents a header name/value
+                                pair
+                              properties:
+                                name:
+                                  description: Name represents a key of a header
+                                  minLength: 1
+                                  type: string
+                                value:
+                                  description: Value represents the value of a header
+                                    specified by a key
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                        type: object
+                      validation:
+                        description: UpstreamValidation defines how to verify the
+                          backend service's certificate
+                        properties:
+                          caSecret:
+                            description: Name of the Kubernetes secret be used to
+                              validate the certificate presented by the backend
+                            type: string
+                          subjectName:
+                            description: Key which is expected to be present in the
+                              'subjectAltName' of the presented certificate
+                            type: string
+                        required:
+                        - caSecret
+                        - subjectName
+                        type: object
+                      weight:
+                        description: Weight defines percentage of traffic to balance
+                          traffic
+                        format: int64
+                        minimum: 0
+                        type: integer
+                    required:
+                    - name
+                    - port
+                    type: object
+                  minItems: 1
+                  type: array
+              required:
+              - services
+              type: object
+            virtualhost:
+              description: Virtualhost appears at most once. If it is present, the
+                object is considered to be a "root".
+              properties:
+                fqdn:
+                  description: The fully qualified domain name of the root of the
+                    ingress tree all leaves of the DAG rooted at this object relate
+                    to the fqdn
+                  type: string
+                tls:
+                  description: If present describes tls properties. The SNI names
+                    that will be matched on are described in fqdn, the tls.secretName
+                    secret must contain a matching certificate
+                  properties:
+                    clientValidation:
+                      description: "ClientValidation defines how to verify the client
+                        certificate when an external client establishes a TLS connection
+                        to Envoy. \n This setting: \n 1. Enables TLS client certificate
+                        validation. 2. Requires clients to present a TLS certificate
+                        (i.e. not optional validation). 3. Specifies how the client
+                        certificate will be validated."
+                      properties:
+                        caSecret:
+                          description: Name of a Kubernetes secret that contains a
+                            CA certificate bundle. The client certificate must validate
+                            against the certificates in the bundle.
+                          minLength: 1
+                          type: string
+                      required:
+                      - caSecret
+                      type: object
+                    enableFallbackCertificate:
+                      description: EnableFallbackCertificate defines if the vhost
+                        should allow a default certificate to be applied which handles
+                        all requests which don't match the SNI defined in this vhost.
+                      type: boolean
+                    minimumProtocolVersion:
+                      description: Minimum TLS version this vhost should negotiate
+                      type: string
+                    passthrough:
+                      description: If Passthrough is set to true, the SecretName will
+                        be ignored and the encrypted handshake will be passed through
+                        to the backing cluster.
+                      type: boolean
+                    secretName:
+                      description: required, the name of a secret in the current namespace
+                      type: string
+                  type: object
+              required:
+              - fqdn
+              type: object
+          type: object
+        status:
+          description: Status reports the current state of the HTTPProxy.
+          properties:
+            currentStatus:
+              type: string
+            description:
+              type: string
+            loadBalancer:
+              description: LoadBalancer contains the current status of the load balancer.
+              properties:
+                ingress:
+                  description: Ingress is a list containing ingress points for the
+                    load-balancer. Traffic intended for the service should be sent
+                    to these ingress points.
+                  items:
+                    description: 'LoadBalancerIngress represents the status of a load-balancer
+                      ingress point: traffic intended for the service should be sent
+                      to an ingress point.'
+                    properties:
+                      hostname:
+                        description: Hostname is set for load-balancer ingress points
+                          that are DNS based (typically AWS load-balancers)
+                        type: string
+                      ip:
+                        description: IP is set for load-balancer ingress points that
+                          are IP based (typically GCE or OpenStack load-balancers)
+                        type: string
+                    type: object
+                  type: array
+              type: object
+          type: object
+      required:
+      - metadata
+      - spec
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: tlscertificatedelegations.projectcontour.io
+spec:
+  group: projectcontour.io
+  names:
+    kind: TLSCertificateDelegation
+    listKind: TLSCertificateDelegationList
+    plural: tlscertificatedelegations
+    shortNames:
+    - tlscerts
+    singular: tlscertificatedelegation
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: TLSCertificateDelegation is an TLS Certificate Delegation CRD specificiation.
+        See design/tls-certificate-delegation.md for details.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: TLSCertificateDelegationSpec defines the spec of the CRD
+          properties:
+            delegations:
+              items:
+                description: CertificateDelegation maps the authority to reference
+                  a secret in the current namespace to a set of namespaces.
+                properties:
+                  secretName:
+                    description: required, the name of a secret in the current namespace.
+                    type: string
+                  targetNamespaces:
+                    description: required, the namespaces the authority to reference
+                      the the secret will be delegated to. If TargetNamespaces is
+                      nil or empty, the CertificateDelegation' is ignored. If the
+                      TargetNamespace list contains the character, "*" the secret
+                      will be delegated to all namespaces.
+                    items:
+                      type: string
+                    type: array
+                required:
+                - secretName
+                - targetNamespaces
+                type: object
+              type: array
+          required:
+          - delegations
+          type: object
+      required:
+      - metadata
+      - spec
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: contour-certgen
+  namespace: projectcontour
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: contour
+  namespace: projectcontour
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: contour-certgen
+subjects:
+- kind: ServiceAccount
+  name: contour-certgen
+  namespace: projectcontour
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: contour-certgen
+  namespace: projectcontour
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - update
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: contour-certgen-v1.6.0
+  namespace: projectcontour
+spec:
+  backoffLimit: 1
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      annotations:
+        linkerd.io/inject: enabled
+      labels:
+        app: contour-certgen
+    spec:
+      containers:
+      - command:
+        - contour
+        - certgen
+        - --kube
+        - --incluster
+        - --overwrite
+        - --secrets-format=compact
+        - --namespace=$(CONTOUR_NAMESPACE)
+        env:
+        - name: CONTOUR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.io/projectcontour/contour:latest
+        imagePullPolicy: Always
+        name: contour
+      restartPolicy: Never
+      securityContext:
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+      serviceAccountName: contour-certgen
+  ttlSecondsAfterFinished: 0
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: contour
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: contour
+subjects:
+- kind: ServiceAccount
+  name: contour
+  namespace: projectcontour
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: contour
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - nodes
+  - pods
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - "ingresses/status"
+  verbs:
+  - get
+  - list
+  - watch
+  - patch 
+  - post
+  - update
+- apiGroups: ["contour.heptio.com"]
+  resources: ["ingressroutes", "tlscertificatedelegations"]
+  verbs:
+  - get
+  - list
+  - watch
+  - put
+  - post
+  - patch
+- apiGroups: ["projectcontour.io"]
+  resources: ["httpproxies", "tlscertificatedelegations"]
+  verbs:
+  - get
+  - list
+  - watch
+  - put
+  - post
+  - patch
+- apiGroups:
+  - "projectcontour.io"
+  resources:
+  - "httpproxies/status"
+  verbs:
+  - update
+- apiGroups: ["networking.x.k8s.io"]
+  resources: ["gatewayclasses", "gateways", "httproutes", "tcproutes"]
+  verbs:
+  - get
+  - list
+  - watch
+  - put
+  - post
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: contour-leaderelection
+  namespace: projectcontour
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: contour-leaderelection
+  namespace: projectcontour
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: contour-leaderelection
+subjects:
+- kind: ServiceAccount
+  name: contour
+  namespace: projectcontour
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: contour
+  namespace: projectcontour
+spec:
+  ports:
+  - port: 8001
+    name: xds
+    protocol: TCP
+    targetPort: 8001
+  selector:
+    app: contour
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: envoy
+  namespace: projectcontour
+  annotations:
+    # This annotation puts the AWS ELB into "TCP" mode so that it does not
+    # do HTTP negotiation for HTTPS connections at the ELB edge.
+    # The downside of this is the remote IP address of all connections will
+    # appear to be the internal address of the ELB. See docs/proxy-proto.md
+    # for information about enabling the PROXY protocol on the ELB to recover
+    # the original remote IP address.
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+spec:
+  externalTrafficPolicy: Local
+  ports:
+  - port: 80
+    name: http
+    protocol: TCP
+  - port: 443
+    name: https
+    protocol: TCP
+  selector:
+    app: envoy
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: contour
+  name: contour
+  namespace: projectcontour
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: contour
+  strategy:
+    rollingUpdate:
+      maxSurge: 50%
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        linkerd.io/inject: enabled
+        prometheus.io/port: "8000"
+        prometheus.io/scrape: "true"
+      labels:
+        app: contour
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: contour
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      containers:
+      - args:
+        - serve
+        - --incluster
+        - --xds-address=0.0.0.0
+        - --xds-port=8001
+        - --envoy-service-http-port=80
+        - --envoy-service-https-port=443
+        - --contour-cafile=/certs/ca.crt
+        - --contour-cert-file=/certs/tls.crt
+        - --contour-key-file=/certs/tls.key
+        - --config-path=/config/contour.yaml
+        command:
+        - contour
+        env:
+        - name: CONTOUR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        image: docker.io/projectcontour/contour:v1.6.1
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+        name: contour
+        ports:
+        - containerPort: 8001
+          name: xds
+          protocol: TCP
+        - containerPort: 8000
+          name: debug
+          protocol: TCP
+        readinessProbe:
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          tcpSocket:
+            port: 8001
+        volumeMounts:
+        - mountPath: /certs
+          name: contourcert
+          readOnly: true
+        - mountPath: /config
+          name: contour-config
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      securityContext:
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+      serviceAccountName: contour
+      volumes:
+      - name: contourcert
+        secret:
+          secretName: contourcert
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: contour.yaml
+            path: contour.yaml
+          name: contour
+        name: contour-config
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: envoy
+  name: envoy
+  namespace: projectcontour
+spec:
+  selector:
+    matchLabels:
+      app: envoy
+  template:
+    metadata:
+      annotations:
+        linkerd.io/inject: enabled
+        prometheus.io/path: /stats/prometheus
+        prometheus.io/port: "8002"
+        prometheus.io/scrape: "true"
+      labels:
+        app: envoy
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - envoy
+        - shutdown-manager
+        command:
+        - /bin/contour
+        image: docker.io/projectcontour/contour:v1.6.1
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            httpGet:
+              path: /shutdown
+              port: 8090
+              scheme: HTTP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8090
+          initialDelaySeconds: 3
+          periodSeconds: 10
+        name: shutdown-manager
+      - args:
+        - -c
+        - /config/envoy.json
+        - --service-cluster $(CONTOUR_NAMESPACE)
+        - --service-node $(ENVOY_POD_NAME)
+        - --log-level info
+        command:
+        - envoy
+        env:
+        - name: CONTOUR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: ENVOY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        image: docker.io/envoyproxy/envoy:v1.14.3
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            httpGet:
+              path: /shutdown
+              port: 8090
+              scheme: HTTP
+        name: envoy
+        ports:
+        - containerPort: 80
+          hostPort: 80
+          name: http
+          protocol: TCP
+        - containerPort: 443
+          hostPort: 443
+          name: https
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8002
+          initialDelaySeconds: 3
+          periodSeconds: 4
+        volumeMounts:
+        - mountPath: /config
+          name: envoy-config
+        - mountPath: /certs
+          name: envoycert
+      initContainers:
+      - args:
+        - bootstrap
+        - /config/envoy.json
+        - --xds-address=contour
+        - --xds-port=8001
+        - --resources-dir=/config/resources
+        - --envoy-cafile=/certs/ca.crt
+        - --envoy-cert-file=/certs/tls.crt
+        - --envoy-key-file=/certs/tls.key
+        command:
+        - contour
+        env:
+        - name: CONTOUR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.io/projectcontour/contour:v1.6.1
+        imagePullPolicy: IfNotPresent
+        name: envoy-initconfig
+        volumeMounts:
+        - mountPath: /config
+          name: envoy-config
+        - mountPath: /certs
+          name: envoycert
+          readOnly: true
+      restartPolicy: Always
+      serviceAccountName: envoy
+      terminationGracePeriodSeconds: 300
+      volumes:
+      - emptyDir: {}
+        name: envoy-config
+      - name: envoycert
+        secret:
+          secretName: envoycert
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate
+---

--- a/testdata/ingress/controllers/traefik.yaml
+++ b/testdata/ingress/controllers/traefik.yaml
@@ -1,0 +1,99 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: traefik-ingress-controller
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+    - extensions
+    resources:
+    - ingresses/status
+    verbs:
+    - update
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: traefik-ingress-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: traefik-ingress-controller
+subjects:
+- kind: ServiceAccount
+  name: traefik-ingress-controller
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: traefik-ingress-controller
+  namespace: kube-system
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: traefik-ingress-controller
+  namespace: kube-system
+  labels:
+    k8s-app: traefik-ingress-lb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: traefik-ingress-lb
+  template:
+    metadata:
+      labels:
+        k8s-app: traefik-ingress-lb
+        name: traefik-ingress-lb
+    spec:
+      serviceAccountName: traefik-ingress-controller
+      terminationGracePeriodSeconds: 60
+      containers:
+      - image: traefik:v1.7
+        name: traefik-ingress-lb
+        ports:
+        - name: http
+          containerPort: 80
+        - name: admin
+          containerPort: 8080
+        args:
+        - --api
+        - --kubernetes
+        - --logLevel=INFO
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: traefik-ingress-controller
+  namespace: kube-system
+spec:
+  selector:
+    k8s-app: traefik-ingress-lb
+  ports:
+    - protocol: TCP
+      port: 80
+      name: web
+    - protocol: TCP
+      port: 8080
+      name: admin
+  type: LoadBalancer

--- a/testdata/ingress/resources/ambassador.yaml
+++ b/testdata/ingress/resources/ambassador.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-ambassador
+  namespace: emojivoto
+  annotations:
+    getambassador.io/config: |
+      ---
+      apiVersion: ambassador/v1
+      kind: Mapping
+      name: web-ambassador-mapping
+      service: http://web-svc.emojivoto.svc.cluster.local:80
+      host: example.com
+      prefix: /
+      add_linkerd_headers: true
+spec:
+  selector:
+    app: web-svc
+  ports:
+  - name: http
+    port: 80
+    targetPort: http

--- a/testdata/ingress/resources/contour.yaml
+++ b/testdata/ingress/resources/contour.yaml
@@ -1,0 +1,17 @@
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: kuard
+  namespace: default
+spec:
+  routes:
+  - requestHeadersPolicy:
+      set:
+      - name: l5d-dst-override
+        value: kuard.default.svc.cluster.local:80
+    services:
+    - name: kuard
+      namespace: default
+      port: 80
+  virtualhost:
+    fqdn: 127.0.0.1.xip.io

--- a/testdata/ingress/resources/gloo.yaml
+++ b/testdata/ingress/resources/gloo.yaml
@@ -1,0 +1,26 @@
+apiVersion: gateway.solo.io/v1
+kind: VirtualService
+metadata:
+  name: books
+  namespace: gloo-system
+spec:
+  virtualHost:
+    domains:
+    - '*'
+    name: gloo-system.books
+    routes:
+    - matcher:
+        prefix: /
+      routeAction:
+        single:
+          upstream:
+            name: booksapp-webapp-7000
+            namespace: gloo-system
+      routePlugins:
+        transformations:
+          requestTransformation:
+            transformationTemplate:
+              headers:
+                l5d-dst-override:
+                  text: webapp.booksapp.svc.cluster.local:7000
+                passthrough: {}

--- a/testdata/ingress/resources/traefik.yaml
+++ b/testdata/ingress/resources/traefik.yaml
@@ -1,0 +1,16 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: web-ingress
+  namespace: emojivoto
+  annotations:
+    kubernetes.io/ingress.class: "traefik"
+    ingress.kubernetes.io/custom-request-headers: l5d-dst-override:web-svc.emojivoto.svc.cluster.local:80
+spec:
+  rules:
+  - host: example.com
+    http:
+      paths:
+      - backend:
+          serviceName: web-svc
+          servicePort: 80

--- a/testdata/kuard.yaml
+++ b/testdata/kuard.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: kuard
+  name: kuard
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: kuard
+  template:
+    metadata:
+      annotations:
+        config.linkerd.io/disable-identity: "true"
+        linkerd.io/inject: enabled
+      labels:
+        app: kuard
+    spec:
+      containers:
+      - image: gcr.io/kuar-demo/kuard-amd64:1
+        name: kuard
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kuard
+  name: kuard
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: kuard
+  sessionAffinity: None
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: kuard
+  labels:
+    app: kuard
+spec:
+  backend:
+    serviceName: kuard
+    servicePort: 80
+---

--- a/utils/config.go
+++ b/utils/config.go
@@ -253,7 +253,7 @@ func (options *ConformanceTestOptions) GetInstallFlags() []string {
 
 // SkipIngress determines if ingress tests must be skipped
 func (options *ConformanceTestOptions) SkipIngress() bool {
-	return options.TestCase.Ingress.Skip
+	return options.TestCase.Ingress.Skip || len(options.TestCase.Ingress.Controllers) == 0
 }
 
 // ShouldTestIngressOfType checks if a given type of ingress must be tested

--- a/utils/consts.go
+++ b/utils/consts.go
@@ -1,11 +1,28 @@
 package utils
 
+var (
+	emojivotoDeploys = map[string]int{
+		"emoji":  1,
+		"voting": 1,
+		"web":    1,
+	}
+
+	booksappDeploys = map[string]int{
+		"webapp":  3,
+		"authors": 1,
+		"books":   1,
+	}
+)
+
 const (
 	defaultNs            = "l5d-conformance"
 	defaultClusterDomain = "cluster.local"
 	defaultPath          = "/.linkerd2/bin/linkerd"
 
 	versionEndpointURL = "https://versioncheck.linkerd.io/version.json"
+
+	emojivotoNs = "emojivoto"
+	booksappNs  = "booksapp"
 
 	//TODO: move these to ConformanceTestOptions while writing Helm tests
 	helmPath        = "target/helm"
@@ -18,25 +35,10 @@ const (
 	multiclusterHelmChart       = "multicluster-helm-chart"
 	multiclusterHelmReleaseName = "multicluster-helm-release"
 
-	installEnv           = "LINKERD2_VERSION"
-	configFile           = "config.yaml"
-	linkerdInstallScript = "install.sh"
-	installScriptURL     = "https://run.linkerd.io/install"
-
-	// string literals for identifying the ingress controllers
-
-	// Nginx holds the string literal "nginx"
-	Nginx = "nginx"
-
-	// Traefik    = "traefik"
-	// GCE        = "gce"
-	// Ambassador = "ambassador"
-	// Gloo       = "gloo"
-	// Contour    = "contour"
-
-	// NginxNs is the namespace in which the nginx controller is installed
-	NginxNs = "ingress-nginx"
-
-	// NginxController is the name of the nginx controller
-	NginxController = "ingress-nginx-controller"
+	installEnv              = "LINKERD2_VERSION"
+	configFile              = "config.yaml"
+	linkerdInstallScript    = "install.sh"
+	glooctlInstallScript    = "gloo_install.sh"
+	linkerdInstallScriptURL = "https://run.linkerd.io/install"
+	glooctlInstallScriptURL = "https://run.solo.io/gloo/install"
 )


### PR DESCRIPTION
closes https://github.com/linkerd/linkerd2-conformance/issues/7

https://github.com/linkerd/linkerd2-conformance/pull/1 introduced tests for ingress to verify the working of ingress-nginx controller with Linkerd. This PR adds tests for the following controllers:

- [x] Traefik
- [x] Contour
- [x] Gloo
- [x] Ambassador