### PR TITLE
stat: Add new test suite for `stat` command

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -32,6 +32,9 @@ testCase:
     tap:
         skip: false
         clean: true
+    stat:
+        skip: false
+        clean: true
     ingress:
         skip: false
         config:

--- a/specs/specs.go
+++ b/specs/specs.go
@@ -43,6 +43,7 @@ func runPrimaryTests() bool {
 		_ = inject.RunInjectTests()
 		_ = tap.RunTapTests()
 		_ = ingress.RunIngressTests()
+		_ = stat.RunStatTests()
 
 		// a separate check for running uninstall must always occur at the end
 		if c.SingleControlPlane() && h.Uninstall() {

--- a/specs/specs.go
+++ b/specs/specs.go
@@ -6,6 +6,7 @@ import (
 	"github.com/linkerd/linkerd2-conformance/specs/ingress"
 	"github.com/linkerd/linkerd2-conformance/specs/inject"
 	"github.com/linkerd/linkerd2-conformance/specs/lifecycle"
+	"github.com/linkerd/linkerd2-conformance/specs/stat"
 	"github.com/linkerd/linkerd2-conformance/specs/tap"
 	"github.com/linkerd/linkerd2-conformance/utils"
 	"github.com/onsi/ginkgo"

--- a/specs/stat/spec.go
+++ b/specs/stat/spec.go
@@ -1,0 +1,31 @@
+package stat
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/linkerd/linkerd2-conformance/utils"
+	"github.com/onsi/ginkgo"
+)
+
+func RunStatTests() bool {
+	return ginkgo.Describe("stat:", func() {
+		ginkgo.It("deploying sample application [emojivoto]", func() {
+			utils.TestEmojivotoApp()
+			utils.TestEmojivotoInject()
+		})
+
+		ginkgo.Context("running", func() {
+			for _, tc := range testCases {
+				tc := tc //pin
+				ginkgo.It(fmt.Sprintf("`linkerd %s`", strings.Join(tc.args, " ")), func() {
+					testStat(tc)
+				})
+			}
+		})
+
+		ginkgo.It("uninstalling sample application [emojivoto]", func() {
+			utils.TestEmojivotoUninstall()
+		})
+	})
+}

--- a/specs/stat/spec.go
+++ b/specs/stat/spec.go
@@ -10,6 +10,9 @@ import (
 
 func RunStatTests() bool {
 	return ginkgo.Describe("stat:", func() {
+		_, c := utils.GetHelperAndConfig()
+		_ = utils.ShouldTestSkip(c.SkipStat(), "Skipping tap tests")
+
 		ginkgo.It("deploying sample application [emojivoto]", func() {
 			utils.TestEmojivotoApp()
 			utils.TestEmojivotoInject()
@@ -24,8 +27,10 @@ func RunStatTests() bool {
 			}
 		})
 
-		ginkgo.It("uninstalling sample application [emojivoto]", func() {
-			utils.TestEmojivotoUninstall()
-		})
+		if c.CleanStat() {
+			ginkgo.It("uninstalling sample application [emojivoto]", func() {
+				utils.TestEmojivotoUninstall()
+			})
+		}
 	})
 }

--- a/specs/stat/tests.go
+++ b/specs/stat/tests.go
@@ -1,0 +1,148 @@
+package stat
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/linkerd/linkerd2-conformance/utils"
+	"github.com/linkerd/linkerd2/testutil"
+	"github.com/onsi/gomega"
+)
+
+var emojivotoNs = "emojivoto"
+
+type testCase struct {
+	args         []string
+	expectedRows map[string]string
+}
+
+var testCases = []testCase{
+	{
+		args: []string{"stat", "deploy", "-n", emojivotoNs},
+		expectedRows: map[string]string{
+			"emoji":    "1/1",
+			"vote-bot": "1/1",
+			"voting":   "1/1",
+			"web":      "1/1",
+		},
+	},
+	{
+		args: []string{"stat", "deploy", "-n", emojivotoNs, "--to", "deploy/emoji"},
+		expectedRows: map[string]string{
+			"web": "1/1",
+		},
+	},
+	{
+		args: []string{"stat", "deploy", "-n", emojivotoNs, "--from", "deploy/web"},
+		expectedRows: map[string]string{
+			"emoji":  "1/1",
+			"voting": "1/1",
+		},
+	},
+	{
+		args: []string{"stat", "deploy", "-n", emojivotoNs, "--to", "svc/emoji-svc"},
+		expectedRows: map[string]string{
+			"web": "1/1",
+		},
+	},
+	{
+		args: []string{"stat", "deploy", "-n", emojivotoNs, "--to", "svc/voting-svc"},
+		expectedRows: map[string]string{
+			"web": "1/1",
+		},
+	},
+	{
+		args: []string{"stat", "deploy", "-n", emojivotoNs, "--to", "svc/web-svc"},
+		expectedRows: map[string]string{
+			"vote-bot": "1/1",
+		},
+	},
+	{
+		args: []string{"stat", "ns", emojivotoNs},
+		expectedRows: map[string]string{
+			"emojivoto": "4/4",
+		},
+	},
+}
+
+func testStat(tc testCase) {
+	h, _ := utils.GetHelperAndConfig()
+	timeout := time.Second * 20
+	err := h.RetryFor(timeout, func() error {
+		tc.args = append(tc.args, "-t", "30s")
+		out, stderr, err := h.LinkerdRun(tc.args...)
+		if err != nil {
+			return fmt.Errorf("failed to run `stat`: %s\n%s", stderr, out)
+		}
+		expectedColumnCount := 8
+
+		rowStats, err := testutil.ParseRows(out, len(tc.expectedRows), expectedColumnCount)
+		if err != nil {
+			return fmt.Errorf("failed to parse rows: %s", err.Error())
+		}
+		for name, meshed := range tc.expectedRows {
+			if err := validateRowStats(name, meshed, rowStats); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+
+	gomega.Expect(err).Should(gomega.BeNil(), utils.Err(err))
+}
+
+func validateRowStats(name, expectedMeshCount string, rowStats map[string]*testutil.RowStat) error {
+	if name == "vote-bot" { // ignore vote-bot
+		return nil
+	}
+
+	stat, ok := rowStats[name]
+	if !ok {
+		return fmt.Errorf("No stats found for [%s]", name)
+
+	}
+
+	if stat.Meshed != expectedMeshCount {
+		return fmt.Errorf("Expected mesh count [%s] for [%s], got [%s]",
+			expectedMeshCount, name, stat.Meshed)
+
+	}
+
+	if !strings.HasSuffix(stat.Rps, "rps") {
+		return fmt.Errorf("Unexpected rps for [%s], got [%s]",
+			name, stat.Rps)
+
+	}
+
+	if !strings.HasSuffix(stat.P50Latency, "ms") {
+		return fmt.Errorf("Unexpected p50 latency for [%s], got [%s]",
+			name, stat.P50Latency)
+
+	}
+
+	if !strings.HasSuffix(stat.P95Latency, "ms") {
+		return fmt.Errorf("Unexpected p95 latency for [%s], got [%s]",
+			name, stat.P95Latency)
+
+	}
+
+	if !strings.HasSuffix(stat.P99Latency, "ms") {
+		return fmt.Errorf("Unexpected p99 latency for [%s], got [%s]",
+			name, stat.P99Latency)
+
+	}
+
+	if stat.TCPOpenConnections != "-" {
+		_, err := strconv.Atoi(stat.TCPOpenConnections)
+		if err != nil {
+			return fmt.Errorf("Error parsing number of TCP connections [%s]: %s", stat.TCPOpenConnections, err.Error())
+
+		}
+
+	}
+
+	return nil
+
+}

--- a/utils/config.go
+++ b/utils/config.go
@@ -62,12 +62,19 @@ type Tap struct {
 	Clean bool `yaml:"clean,omitempty"`
 }
 
+// Stat holds the configuration for stat test
+type Stat struct {
+	Skip  bool `yaml:"skip,omitempty"`
+	Clean bool `yaml:"clean,omitempty"`
+}
+
 // TestCase holds configuration of the various test cases
 type TestCase struct {
 	Lifecycle `yaml:"lifecycle,omitempty"`
 	Inject    `yaml:"inject"`
 	Ingress   `yaml:"ingress"`
 	Tap       `yaml:"tap"`
+	Stat      `yaml:"stat"`
 }
 
 // ConformanceTestOptions holds the values fed from the test config file
@@ -322,4 +329,14 @@ func (options *ConformanceTestOptions) SkipTap() bool {
 // CleanTap checks if tap resources must be deleted
 func (options *ConformanceTestOptions) CleanTap() bool {
 	return options.TestCase.Tap.Clean
+}
+
+// SkipStat checks if `stat` test must be skipped
+func (options *ConformanceTestOptions) SkipStat() bool {
+	return options.TestCase.Stat.Skip
+}
+
+// CleanStat checks if stat test resources must be deleted
+func (options *ConformanceTestOptions) CleanStat() bool {
+	return options.TestCase.Stat.Clean
 }


### PR DESCRIPTION
This PR adds tests for `linkerd stat` by testing against emojivoto:
- `linkerd stat deploy -n emojivoto`
- `linkerd stat deploy -n emojivoto --to deploy/emoji`
- `linkerd stat deploy -n emojivoto --from deploy/web`
-  `linkerd stat deploy -n emojivoto --to svc/emoji-svc`
- `linkerd stat deploy -n emojivoto --to svc/voting-svc`
- `linkerd stat deploy -n emojivoto --to svc/web-svc`
- `linkerd stat ns emojivoto`

To do:
- [ ] Add config for `stat`
- [ ] Finish wiring up with `specs/spec.go`

Waiting on https://github.com/linkerd/linkerd2-conformance/pull/16 and https://github.com/linkerd/linkerd2-conformance/pull/12 to get merged, followed by a refactor that may cause multiple merge conflicts.

Signed-off-by: Mayank Shah <mayankshah1614@gmail.com>