### PR TITLE
Refactor Gomega assertions

### DIFF
--- a/utils/gomega_helpers.go
+++ b/utils/gomega_helpers.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"fmt"
+
+	"github.com/onsi/gomega"
+)
+
+func ExpectNil(item interface{}, annotation string, args ...interface{}) {
+	gomega.Expect(item).Should(gomega.BeNil(), fmt.Sprintf(annotation, args...))
+}
+
+func ExpectSubstring(item, substring, annotation string, args ...interface{}) {
+	gomega.Expect(item).Should(gomega.ContainSubstring(substring), fmt.Sprintf(annotation, args...))
+}
+
+func ExpectEqual(received, expected interface{}, annotation string, args ...interface{}) {
+	gomega.Expect(received).Should(gomega.Equal(expected),
+		fmt.Sprintf(annotation, args...))
+}
+
+func ExpectTrue(item interface{}, annotation string, args ...interface{}) {
+	gomega.Expect(item).Should(gomega.BeTrue(), fmt.Sprintf(annotation, args...))
+}

--- a/utils/test_helpers.go
+++ b/utils/test_helpers.go
@@ -62,7 +62,6 @@ func RunCheck(h *testutil.TestHelper, pre bool) {
 
 	if pre {
 		cmd = append(cmd, "--pre")
-	} else {
 	}
 
 	out, stderr, err := h.LinkerdRun(cmd...)


### PR DESCRIPTION
- Create reusable helper functions in `utils` package to prevent
rewriting long Gomega assertions
- Remove  redundant `ginkgo.By` messages to keep logs clean
- Add line breaks wherever required 

Signed-off-by: Mayank Shah <mayankshah1614@gmail.com>