### PR TITLE
routes: Add tests for `routes` command

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -45,3 +45,6 @@ testCase:
                   clean: true
                 - name: traefik
                   clean: true
+    routes:
+        skip: false
+        clean: true

--- a/config.yaml
+++ b/config.yaml
@@ -36,7 +36,7 @@ testCase:
         skip: false
         clean: true
     ingress:
-        skip: false
+        skip: true
         config:
             controllers:
                 - name: nginx

--- a/config.yaml
+++ b/config.yaml
@@ -36,7 +36,7 @@ testCase:
         skip: false
         clean: true
     ingress:
-        skip: true
+        skip: false
         config:
             controllers:
                 - name: nginx

--- a/specs/routes/spec.go
+++ b/specs/routes/spec.go
@@ -1,0 +1,14 @@
+package routes
+
+import "github.com/onsi/ginkgo"
+
+func RunRoutesTests() bool {
+	return ginkgo.Describe("routes:", func() {
+		ginkgo.It("installing smoke-test application", testInstallSmokeTest)
+		ginkgo.It("installing ServiceProfiles for smoke-test", testInstallSPSmokeTest)
+		ginkgo.It("installing ServiceProfiles for control plane", testInstallSPContolPlane)
+		ginkgo.It("running `linkerd routes`", testRoutes)
+		ginkgo.It("uninstalling smoke-test", testUninstallSmokeTest)
+		ginkgo.It("uninstalling control plane ServiceProfiles", testUninstallControlPlaneServiceProfile)
+	})
+}

--- a/specs/routes/spec.go
+++ b/specs/routes/spec.go
@@ -1,14 +1,23 @@
 package routes
 
-import "github.com/onsi/ginkgo"
+import (
+	"github.com/linkerd/linkerd2-conformance/utils"
+	"github.com/onsi/ginkgo"
+)
 
 func RunRoutesTests() bool {
 	return ginkgo.Describe("routes:", func() {
+		_, c := utils.GetHelperAndConfig()
+		_ = utils.ShouldTestSkip(c.SkipRoutes(), "Skipping routes test")
+
 		ginkgo.It("installing smoke-test application", testInstallSmokeTest)
 		ginkgo.It("installing ServiceProfiles for smoke-test", testInstallSPSmokeTest)
 		ginkgo.It("installing ServiceProfiles for control plane", testInstallSPContolPlane)
 		ginkgo.It("running `linkerd routes`", testRoutes)
-		ginkgo.It("uninstalling smoke-test", testUninstallSmokeTest)
-		ginkgo.It("uninstalling control plane ServiceProfiles", testUninstallControlPlaneServiceProfile)
+
+		if c.CleanRoutes() {
+			ginkgo.It("uninstalling smoke-test", testUninstallSmokeTest)
+			ginkgo.It("uninstalling control plane ServiceProfiles", testUninstallControlPlaneServiceProfile)
+		}
 	})
 }

--- a/specs/routes/tests.go
+++ b/specs/routes/tests.go
@@ -17,14 +17,17 @@ func testInstallSmokeTest() {
 
 	cmd := []string{"inject", "testdata/routes/smoke_test.yaml"}
 	out, stderr, err := h.LinkerdRun(cmd...)
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to inject manifests: %s\n%s", utils.Err(err), stderr))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("failed to inject manifests: %s\n%s", utils.Err(err), stderr))
 
 	prefixedNs := h.GetTestNamespace(ns)
 	err = h.CreateDataPlaneNamespaceIfNotExists(prefixedNs, map[string]string{})
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to create namespace: %s", utils.Err(err)))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("failed to create namespace: %s", utils.Err(err)))
 
 	out, err = h.KubectlApply(out, prefixedNs)
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to create resources %s\n%s", utils.Err(err), out))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("failed to create resources %s\n%s", utils.Err(err), out))
 
 	for _, deploy := range []string{"smoke-test-terminus", "smoke-test-gateway"} {
 		if err := h.CheckPods(prefixedNs, deploy, 1); err != nil {
@@ -35,12 +38,15 @@ func testInstallSmokeTest() {
 	}
 
 	url, err := h.URLFor(prefixedNs, "smoke-test-gateway", 8080)
-	gomega.Expect(err).Should(gomega.BeNil(), "failed to get URL for [smoke-test-gateway]")
+	gomega.Expect(err).Should(gomega.BeNil(),
+		"failed to get URL for [smoke-test-gateway]")
 	output, err := h.HTTPGetURL(url)
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to reach smoke-test-gateway: %s\n%s", utils.Err(err), output))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("failed to reach smoke-test-gateway: %s\n%s", utils.Err(err), output))
 
 	expectedStringPayload := "\"payload\":\"BANANA\""
-	gomega.Expect(output).Should(gomega.ContainSubstring(expectedStringPayload), fmt.Sprintf("output does not contain expected substring"))
+	gomega.Expect(output).Should(gomega.ContainSubstring(expectedStringPayload),
+		"output does not contain expected substring")
 }
 
 func testInstallSPSmokeTest() {
@@ -48,14 +54,17 @@ func testInstallSPSmokeTest() {
 	prefixedNs := h.GetTestNamespace(ns)
 
 	bbProto, err := testutil.ReadFile("testdata/routes/api.proto")
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to read proto file: %s", utils.Err(err)))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("failed to read proto file: %s", utils.Err(err)))
 
 	cmd := []string{"profile", "-n", prefixedNs, "--proto", "-", "smoke-test-terminus-svc"}
 	bbSP, stderr, err := h.PipeToLinkerdRun(bbProto, cmd...)
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to produce ServiceProfiles: %s\n%s", utils.Err(err), stderr))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("failed to produce ServiceProfiles: %s\n%s", utils.Err(err), stderr))
 
 	out, err := h.KubectlApply(bbSP, prefixedNs)
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to install ServiceProfiles: %s\n%s", utils.Err(err), out))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("failed to install ServiceProfiles: %s\n%s", utils.Err(err), out))
 }
 
 func testInstallSPContolPlane() {
@@ -64,10 +73,12 @@ func testInstallSPContolPlane() {
 	cmd := []string{"install-sp"}
 
 	out, stderr, err := h.LinkerdRun(cmd...)
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to generate ServiceProfiles: %s\n%s", utils.Err(err), stderr))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("failed to generate ServiceProfiles: %s\n%s", utils.Err(err), stderr))
 
 	out, err = h.KubectlApply(out, h.GetLinkerdNamespace())
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to install ServiceProfiles: %s\n%s", utils.Err(err), out))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("failed to install ServiceProfiles: %s\n%s", utils.Err(err), out))
 }
 
 func testRoutes() {
@@ -77,7 +88,8 @@ func testRoutes() {
 
 	cmd := []string{"routes", "--namespace", h.GetLinkerdNamespace(), "deploy"}
 	out, stderr, err := h.LinkerdRun(cmd...)
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("`linkerd routes` command failed: %s\n%s", out, stderr))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("`linkerd routes` command failed: %s\n%s", out, stderr))
 
 	routeStrings := []struct {
 		s string
@@ -102,7 +114,8 @@ func testRoutes() {
 
 	for _, r := range routeStrings {
 		count := strings.Count(out, r.s)
-		gomega.Expect(count).Should(gomega.Equal(r.c), fmt.Sprintf("expected %d occurences of %s, got %d", r.c, r.s, count))
+		gomega.Expect(count).Should(gomega.Equal(r.c),
+			fmt.Sprintf("expected %d occurences of %s, got %d", r.c, r.s, count))
 	}
 
 	ginkgo.By("Testing smoke-test routes")
@@ -111,10 +124,12 @@ func testRoutes() {
 	golden := "routes/routes.smoke.golden"
 
 	out, stderr, err = h.LinkerdRun(cmd...)
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("`linkerd routes` command failed: %s\n%s", out, stderr))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("`linkerd routes` command failed: %s\n%s", out, stderr))
 
 	err = h.ValidateOutput(out, golden)
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to validate output: %s", utils.Err(err)))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("failed to validate output: %s", utils.Err(err)))
 }
 
 func testUninstallSmokeTest() {
@@ -122,7 +137,8 @@ func testUninstallSmokeTest() {
 	prefixedNs := h.GetTestNamespace(ns)
 
 	out, err := h.Kubectl("", "delete", "ns", prefixedNs)
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("`kubectl delete` command failed: %s\n%s", utils.Err(err), out))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("`kubectl delete` command failed: %s\n%s", utils.Err(err), out))
 
 }
 
@@ -132,8 +148,10 @@ func testUninstallControlPlaneServiceProfile() {
 	cmd := []string{"install-sp"}
 
 	out, stderr, err := h.LinkerdRun(cmd...)
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to generate ServiceProfiles: %s\n%s", utils.Err(err), stderr))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("failed to generate ServiceProfiles: %s\n%s", utils.Err(err), stderr))
 
 	out, err = h.Kubectl(out, "-n", h.GetLinkerdNamespace(), "delete", "-f", "-")
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to remove ServiceProfiles: %s\n%s", utils.Err(err), out))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("failed to remove ServiceProfiles: %s\n%s", utils.Err(err), out))
 }

--- a/specs/routes/tests.go
+++ b/specs/routes/tests.go
@@ -1,0 +1,139 @@
+package routes
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/linkerd/linkerd2-conformance/utils"
+	"github.com/linkerd/linkerd2/testutil"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+var ns = "smoke-test"
+
+func testInstallSmokeTest() {
+	h, _ := utils.GetHelperAndConfig()
+
+	cmd := []string{"inject", "testdata/routes/smoke_test.yaml"}
+	out, stderr, err := h.LinkerdRun(cmd...)
+	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to inject manifests: %s\n%s", utils.Err(err), stderr))
+
+	prefixedNs := h.GetTestNamespace(ns)
+	err = h.CreateDataPlaneNamespaceIfNotExists(prefixedNs, map[string]string{})
+	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to create namespace: %s", utils.Err(err)))
+
+	out, err = h.KubectlApply(out, prefixedNs)
+	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to create resources %s\n%s", utils.Err(err), out))
+
+	for _, deploy := range []string{"smoke-test-terminus", "smoke-test-gateway"} {
+		if err := h.CheckPods(prefixedNs, deploy, 1); err != nil {
+			if _, ok := err.(*testutil.RestartCountError); !ok {
+				ginkgo.Fail(fmt.Sprintf("CheckPods timed-out: %s", err.Error()))
+			}
+		}
+	}
+
+	url, err := h.URLFor(prefixedNs, "smoke-test-gateway", 8080)
+	gomega.Expect(err).Should(gomega.BeNil(), "failed to get URL for [smoke-test-gateway]")
+	output, err := h.HTTPGetURL(url)
+	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to reach smoke-test-gateway: %s\n%s", utils.Err(err), output))
+
+	expectedStringPayload := "\"payload\":\"BANANA\""
+	gomega.Expect(output).Should(gomega.ContainSubstring(expectedStringPayload), fmt.Sprintf("output does not contain expected substring"))
+}
+
+func testInstallSPSmokeTest() {
+	h, _ := utils.GetHelperAndConfig()
+	prefixedNs := h.GetTestNamespace(ns)
+
+	bbProto, err := testutil.ReadFile("testdata/routes/api.proto")
+	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to read proto file: %s", utils.Err(err)))
+
+	cmd := []string{"profile", "-n", prefixedNs, "--proto", "-", "smoke-test-terminus-svc"}
+	bbSP, stderr, err := h.PipeToLinkerdRun(bbProto, cmd...)
+	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to produce ServiceProfiles: %s\n%s", utils.Err(err), stderr))
+
+	out, err := h.KubectlApply(bbSP, prefixedNs)
+	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to install ServiceProfiles: %s\n%s", utils.Err(err), out))
+}
+
+func testInstallSPContolPlane() {
+	h, _ := utils.GetHelperAndConfig()
+
+	cmd := []string{"install-sp"}
+
+	out, stderr, err := h.LinkerdRun(cmd...)
+	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to generate ServiceProfiles: %s\n%s", utils.Err(err), stderr))
+
+	out, err = h.KubectlApply(out, h.GetLinkerdNamespace())
+	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to install ServiceProfiles: %s\n%s", utils.Err(err), out))
+}
+
+func testRoutes() {
+	h, _ := utils.GetHelperAndConfig()
+
+	ginkgo.By("Testing control plane routes")
+
+	cmd := []string{"routes", "--namespace", h.GetLinkerdNamespace(), "deploy"}
+	out, stderr, err := h.LinkerdRun(cmd...)
+	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("`linkerd routes` command failed: %s\n%s", out, stderr))
+
+	routeStrings := []struct {
+		s string
+		c int
+	}{
+		{"linkerd-controller-api", 7},
+		{"linkerd-destination", 1},
+		{"linkerd-dst", 3},
+		{"linkerd-grafana", 13},
+		{"linkerd-identity", 2},
+		{"linkerd-prometheus", 5},
+		{"linkerd-web", 2},
+
+		{"POST /api/v1/ListPods", 1},
+		{"POST /api/v1/", 7},
+		{"POST /io.linkerd.proxy.destination.Destination/Get", 2},
+		{"GET /api/annotations", 1},
+		{"GET /api/", 9},
+		{"GET /public/", 3},
+		{"GET /api/v1/", 2},
+	}
+
+	for _, r := range routeStrings {
+		count := strings.Count(out, r.s)
+		gomega.Expect(count).Should(gomega.Equal(r.c), fmt.Sprintf("expected %d occurences of %s, got %d", r.c, r.s, count))
+	}
+
+	ginkgo.By("Testing smoke-test routes")
+	prefixedNs := h.GetTestNamespace(ns)
+	cmd = []string{"routes", "--namespace", prefixedNs, "deploy"}
+	golden := "routes/routes.smoke.golden"
+
+	out, stderr, err = h.LinkerdRun(cmd...)
+	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("`linkerd routes` command failed: %s\n%s", out, stderr))
+
+	err = h.ValidateOutput(out, golden)
+	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to validate output: %s", utils.Err(err)))
+}
+
+func testUninstallSmokeTest() {
+	h, _ := utils.GetHelperAndConfig()
+	prefixedNs := h.GetTestNamespace(ns)
+
+	out, err := h.Kubectl("", "delete", "ns", prefixedNs)
+	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("`kubectl delete` command failed: %s\n%s", utils.Err(err), out))
+
+}
+
+func testUninstallControlPlaneServiceProfile() {
+	h, _ := utils.GetHelperAndConfig()
+
+	cmd := []string{"install-sp"}
+
+	out, stderr, err := h.LinkerdRun(cmd...)
+	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to generate ServiceProfiles: %s\n%s", utils.Err(err), stderr))
+
+	out, err = h.Kubectl(out, "-n", h.GetLinkerdNamespace(), "delete", "-f", "-")
+	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to remove ServiceProfiles: %s\n%s", utils.Err(err), out))
+}

--- a/specs/specs.go
+++ b/specs/specs.go
@@ -6,6 +6,7 @@ import (
 	"github.com/linkerd/linkerd2-conformance/specs/ingress"
 	"github.com/linkerd/linkerd2-conformance/specs/inject"
 	"github.com/linkerd/linkerd2-conformance/specs/lifecycle"
+	"github.com/linkerd/linkerd2-conformance/specs/routes"
 	"github.com/linkerd/linkerd2-conformance/specs/stat"
 	"github.com/linkerd/linkerd2-conformance/specs/tap"
 	"github.com/linkerd/linkerd2-conformance/utils"
@@ -45,6 +46,7 @@ func runPrimaryTests() bool {
 		_ = tap.RunTapTests()
 		_ = ingress.RunIngressTests()
 		_ = stat.RunStatTests()
+		_ = routes.RunRoutesTests()
 
 		// a separate check for running uninstall must always occur at the end
 		if c.SingleControlPlane() && h.Uninstall() {

--- a/testdata/routes/api.proto
+++ b/testdata/routes/api.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package buoyantio.bb;
+
+message TheRequest {
+    string requestUID = 1;
+}
+
+message TheResponse {
+    string requestUID = 1;
+    string payload = 2;
+}
+
+service TheService {
+    rpc theFunction (TheRequest) returns (TheResponse) {
+    }
+}

--- a/testdata/routes/routes.smoke.golden
+++ b/testdata/routes/routes.smoke.golden
@@ -1,0 +1,9 @@
+==> deployment/smoke-test-gateway <==
+ROUTE                      SERVICE   SUCCESS   RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99
+[DEFAULT]   smoke-test-gateway-svc         -     -             -             -             -
+
+==> deployment/smoke-test-terminus <==
+ROUTE                         SERVICE   SUCCESS   RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99
+[DEFAULT]     smoke-test-terminus-svc         -     -             -             -             -
+theFunction   smoke-test-terminus-svc         -     -             -             -             -
+

--- a/testdata/routes/smoke_test.yaml
+++ b/testdata/routes/smoke_test.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: smoke-test-terminus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: smoke-test-terminus
+  template:
+    metadata:
+      labels:
+        app: smoke-test-terminus
+    spec:
+      containers:
+      - name: http-to-grpc
+        image: buoyantio/bb:v0.0.5
+        args: ["terminus", "--grpc-server-port", "9090", "--response-text", "BANANA"]
+        ports:
+        - containerPort: 9090
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: smoke-test-terminus-svc
+spec:
+  selector:
+    app: smoke-test-terminus
+  ports:
+  - name: grpc
+    port: 9090
+    targetPort: 9090
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: smoke-test-gateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: smoke-test-gateway
+  template:
+    metadata:
+      labels:
+        app: smoke-test-gateway
+    spec:
+      containers:
+      - name: http-to-grpc
+        image: buoyantio/bb:v0.0.5
+        args: ["point-to-point-channel", "--grpc-downstream-server", "smoke-test-terminus-svc:9090", "--h1-server-port", "8080"]
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: smoke-test-gateway-svc
+spec:
+  selector:
+    app: smoke-test-gateway
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080

--- a/utils/config.go
+++ b/utils/config.go
@@ -64,6 +64,10 @@ type Tap struct {
 
 // Stat holds the configuration for stat test
 type Stat struct {
+	// Routes holds the configuration for `routes` tests
+}
+
+type Routes struct {
 	Skip  bool `yaml:"skip,omitempty"`
 	Clean bool `yaml:"clean,omitempty"`
 }
@@ -75,6 +79,7 @@ type TestCase struct {
 	Ingress   `yaml:"ingress"`
 	Tap       `yaml:"tap"`
 	Stat      `yaml:"stat"`
+	Routes    `yaml:"routes"`
 }
 
 // ConformanceTestOptions holds the values fed from the test config file
@@ -319,6 +324,16 @@ func (options *ConformanceTestOptions) ShouldCleanIngressInstallation(t string) 
 		}
 	}
 	return false
+}
+
+// SkipRoutes checks if tap tests should be skipped
+func (options *ConformanceTestOptions) SkipRoutes() bool {
+	return options.TestCase.Routes.Skip
+}
+
+// CleanRoutes checks if tap resources must be deleted
+func (options *ConformanceTestOptions) CleanRoutes() bool {
+	return options.TestCase.Routes.Clean
 }
 
 // SkipTap checks if tap tests should be skipped

--- a/utils/config.go
+++ b/utils/config.go
@@ -64,9 +64,11 @@ type Tap struct {
 
 // Stat holds the configuration for stat test
 type Stat struct {
-	// Routes holds the configuration for `routes` tests
+	Skip  bool `yaml:"skip,omitempty"`
+	Clean bool `yaml:"clean,omitempty"`
 }
 
+// Routes holds the configuration for `routes` tests
 type Routes struct {
 	Skip  bool `yaml:"skip,omitempty"`
 	Clean bool `yaml:"clean,omitempty"`


### PR DESCRIPTION
This PR adds tests for `routes` command. The tests have been derived from the integration tests for `routes`:

- install smoke test application
- install ServiceProfiles for Linkerd control plane and the sample application
- test routes for both use cases
- uninstall all the installed resources

Signed-off-by: Mayank Shah <mayankshah1614@gmail.com>