### PR TITLE
Omit flaky `linkerd inject --manual` output validation

### DIFF
--- a/specs/inject/tests.go
+++ b/specs/inject/tests.go
@@ -18,7 +18,7 @@ var (
 )
 
 func testInjectManual(withParams bool) {
-	var golden string
+	// var golden string
 
 	h, _ := utils.GetHelperAndConfig()
 
@@ -54,20 +54,25 @@ func testInjectManual(withParams bool) {
 		}
 		cmd = append(cmd, params...)
 
-		golden = "inject/inject_params.golden"
-	} else {
-		golden = "inject/inject_default.golden"
+		// golden = "inject/inject_params.golden"
 	}
+	// else {
+	// 	golden = "inject/inject_default.golden"
+	// }
 	cmd = append(cmd, injectYAMLPath)
 
 	ginkgo.By(fmt.Sprintf("Running `linkerd inject` against %s", injectYAMLPath))
 	out, stderr, err := h.LinkerdRun(cmd...)
 
-	gomega.Expect(err).Should(gomega.BeNil(), stderr)
+	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to run `linkerd inject`: %s\n%s", out, stderr))
 
-	ginkgo.By("Validating injected output")
-	err = testutil.ValidateInject(out, golden, h)
-	gomega.Expect(err).To(gomega.BeNil())
+	// This part is flaky and is being temporarily omitted.
+	// The output of `linkerd inject --manual` may differ
+	// depending on the version of Linkerd CLI mentioned in the `config.yaml`
+
+	// ginkgo.By("Validating injected output")
+	// err = testutil.ValidateInject(out, golden, h)
+	// gomega.Expect(err).To(gomega.BeNil())
 }
 
 func testProxyInjection() {


### PR DESCRIPTION
This PR temporarily mutes the text validation part of `linkerd inject --manual` test case. This has to be done because currently manual injection is tested by validating the text output against a predefined `.golden` file that holds the expected output. This approach may often fail because `linkerd inject --manual` may have a different text output depending on the version of Linkerd used (mentioned in the `config.yaml`; by default its the latest edge). Until we figure out a better way to validate the output, this part of the test case needs to be omitted to prevent flakiness.

Signed-off-by: Mayank Shah <mayankshah1614@gmail.com>