### PR TITLE
Clean up lifecycle and inject tests

### DIFF
--- a/specs/inject/tests.go
+++ b/specs/inject/tests.go
@@ -7,7 +7,6 @@ import (
 	"github.com/linkerd/linkerd2-conformance/utils"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/testutil"
-	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -34,7 +33,6 @@ func testInjectManual(withParams bool) {
 	}
 
 	if withParams {
-		ginkgo.By("Adding manual parameters to `linkerd inject`")
 		params := []string{
 			"--disable-tap",
 			"--image-pull-policy=Never",
@@ -61,10 +59,10 @@ func testInjectManual(withParams bool) {
 	// }
 	cmd = append(cmd, injectYAMLPath)
 
-	ginkgo.By(fmt.Sprintf("Running `linkerd inject` against %s", injectYAMLPath))
 	out, stderr, err := h.LinkerdRun(cmd...)
 
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to run `linkerd inject`: %s\n%s", out, stderr))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("failed to run `linkerd inject`: %s\n%s", out, stderr))
 
 	// This part is flaky and is being temporarily omitted.
 	// The output of `linkerd inject --manual` may differ
@@ -78,7 +76,6 @@ func testInjectManual(withParams bool) {
 func testProxyInjection() {
 	h, _ := utils.GetHelperAndConfig()
 
-	ginkgo.By("Reading pod YAML")
 	podYAML, err := testutil.ReadFile("testdata/inject/pod.yaml")
 
 	gomega.Expect(err).Should(gomega.BeNil(), utils.Err(err))
@@ -90,22 +87,25 @@ func testProxyInjection() {
 	}
 
 	proxyInjectTestNs = h.GetTestNamespace(injectNs)
-	ginkgo.By(fmt.Sprintf("Creating data plane namespace %s", proxyInjectTestNs))
 	err = h.CreateDataPlaneNamespaceIfNotExists(proxyInjectTestNs, nsAnnotations)
 
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to create namespace %s: %s", proxyInjectTestNs, utils.Err(err)))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("failed to create namespace %s: %s", proxyInjectTestNs, utils.Err(err)))
 
-	ginkgo.By(fmt.Sprintf("Creating test pod in namespace %s", proxyInjectTestNs))
 	o, err := h.Kubectl(podYAML, "-n", proxyInjectTestNs, "create", "-f", "-")
 
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to create pod/%s in namespace %s for %s: %s", podName, proxyInjectTestNs, utils.Err(err), o))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("failed to create pod/%s in namespace %s for %s: %s",
+			podName, proxyInjectTestNs, utils.Err(err), o))
 
-	ginkgo.By("Waiting for pod to be initialized")
-	o, err = h.Kubectl("", "-n", proxyInjectTestNs, "wait", "--for=condition=initialized", "--timeout=120s", "pod/"+podName)
+	o, err = h.Kubectl("", "-n", proxyInjectTestNs, "wait",
+		"--for=condition=initialized",
+		"--timeout=120s", "pod/"+podName)
 
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to wait for pod/%s to be initialized in namespace %s: %s: %s", podName, proxyInjectTestNs, utils.Err(err), o))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("failed to wait for pod/%s to be initialized in namespace %s: %s: %s",
+			podName, proxyInjectTestNs, utils.Err(err), o))
 
-	ginkgo.By("Checking for existence of proxy container")
 	err = h.RetryFor(time.Minute*3, func() error {
 		pods, err := h.GetPods(proxyInjectTestNs, map[string]string{"app": podName})
 		if err != nil {
@@ -127,7 +127,6 @@ func testInjectAutoNsOverrideAnnotations() {
 
 	h, _ := utils.GetHelperAndConfig()
 
-	ginkgo.By("Reading pod YAML")
 	injectYAML, err := testutil.ReadFile("testdata/inject/inject_test.yaml")
 
 	gomega.Expect(err).Should(gomega.BeNil(), utils.Err(err))
@@ -145,42 +144,50 @@ func testInjectAutoNsOverrideAnnotations() {
 
 	nsAnnotationsOverrideTestNs = h.GetTestNamespace(injectNs)
 
-	ginkgo.By(fmt.Sprintf("Creating data plane namespace %s", proxyInjectTestNs))
 	err = h.CreateDataPlaneNamespaceIfNotExists(nsAnnotationsOverrideTestNs, nsAnnotations)
 
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to create namespace %s: %s", nsAnnotationsOverrideTestNs, utils.Err(err)))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("failed to create namespace %s: %s",
+			nsAnnotationsOverrideTestNs, utils.Err(err)))
 
 	podProxyCPUReq := "600m"
 	podAnnotations := map[string]string{
 		k8s.ProxyCPURequestAnnotation: podProxyCPUReq,
 	}
 
-	ginkgo.By("Patching inject test YAML")
 	patchedYAML, err := testutil.PatchDeploy(injectYAML, deployName, podAnnotations)
 
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to patch inject test YAML in namespace %s for deploy/%s: %s", nsAnnotationsOverrideTestNs, deployName, utils.Err(err)))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("failed to patch inject test YAML in namespace %s for deploy/%s: %s",
+			nsAnnotationsOverrideTestNs, deployName, utils.Err(err)))
 
-	ginkgo.By("Applying patched YAML to your cluster")
 	o, err := h.Kubectl(patchedYAML, "-n", nsAnnotationsOverrideTestNs, "create", "-f", "-")
 
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to create deploy/%s in namespace %s for  %s: %s", deployName, nsAnnotationsOverrideTestNs, utils.Err(err), o))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("failed to create deploy/%s in namespace %s for  %s: %s",
+			deployName, nsAnnotationsOverrideTestNs, utils.Err(err), o))
 
-	ginkgo.By(fmt.Sprintf("Waiting for deploy/%s to be available", deployName))
-	o, err = h.Kubectl("", "--namespace", nsAnnotationsOverrideTestNs, "wait", "--for=condition=available", "--timeout=120s", "deploy/"+deployName)
+	o, err = h.Kubectl("", "--namespace", nsAnnotationsOverrideTestNs,
+		"wait", "--for=condition=available", "--timeout=120s", "deploy/"+deployName)
 
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to wait for deploy/%s in namespace %s for  %s: %s", deployName, nsAnnotationsOverrideTestNs, utils.Err(err), o))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("failed to wait for deploy/%s in namespace %s for  %s: %s",
+			deployName, nsAnnotationsOverrideTestNs, utils.Err(err), o))
 
-	ginkgo.By(fmt.Sprintf("Getting pods for deploy/%s in namespace %s", deployName, nsAnnotationsOverrideTestNs))
 	pods, err := h.GetPodsForDeployment(nsAnnotationsOverrideTestNs, deployName)
 
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to get pods for namespace %s: %s", nsAnnotationsOverrideTestNs, utils.Err(err)))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("failed to get pods for namespace %s: %s",
+			nsAnnotationsOverrideTestNs, utils.Err(err)))
 
 	containers := pods[0].Spec.Containers
 	proxyContainer := testutil.GetProxyContainer(containers)
 
-	ginkgo.By("Matching pod configuration with namespace level overrides")
-	gomega.Expect(proxyContainer.Resources.Requests["memory"]).Should(gomega.Equal(resource.MustParse(nsProxyMemReq)), "proxy memory resource request failed to match with namespace level override")
-	gomega.Expect(proxyContainer.Resources.Requests["cpu"]).Should(gomega.Equal(resource.MustParse(podProxyCPUReq)), "proxy cpu resource request failed to match with namespace level override")
+	gomega.Expect(proxyContainer.Resources.Requests["memory"]).Should(gomega.Equal(resource.MustParse(nsProxyMemReq)),
+		"proxy memory resource request failed to match with namespace level override")
+
+	gomega.Expect(proxyContainer.Resources.Requests["cpu"]).Should(gomega.Equal(resource.MustParse(podProxyCPUReq)),
+		"proxy cpu resource request failed to match with namespace level override")
 }
 
 func testClean() {
@@ -192,18 +199,18 @@ func testClean() {
 	}
 
 	for _, ns := range namespaces {
-		ginkgo.By(fmt.Sprintf("Gathering manifests for namespace/%s", ns))
 		out, err := h.Kubectl("", "-n", ns, "get", "all", "-o", "yaml")
 
 		gomega.Expect(err).Should(gomega.BeNil(), utils.Err(err))
 
-		ginkgo.By(fmt.Sprintf("Deleting resources in namespace/%s", ns))
 		_, err = h.Kubectl(out, "delete", "-f", "-")
 
-		gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("could not delete resources in namespace/%s: %s", ns, utils.Err(err)))
+		gomega.Expect(err).Should(gomega.BeNil(),
+			fmt.Sprintf("could not delete resources in namespace/%s: %s", ns, utils.Err(err)))
 
 		_, err = h.Kubectl("", "delete", "ns", ns)
 
-		gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("could not delete namespace %s: %s", ns, utils.Err(err)))
+		gomega.Expect(err).Should(gomega.BeNil(),
+			fmt.Sprintf("could not delete namespace %s: %s", ns, utils.Err(err)))
 	}
 }

--- a/specs/lifecycle/tests.go
+++ b/specs/lifecycle/tests.go
@@ -4,14 +4,11 @@ import (
 	"fmt"
 
 	"github.com/linkerd/linkerd2-conformance/utils"
-	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 )
 
 func testUpgradeCLI() {
 	h, c := utils.GetHelperAndConfig()
-
-	ginkgo.By(fmt.Sprintf("Upgrading CLI from version %s to %s", h.UpgradeFromVersion(), h.GetVersion()))
 
 	err := utils.InstallLinkerdBinary(c.GetLinkerdPath(), h.GetVersion(), true, false)
 	gomega.Expect(err).Should(gomega.BeNil(), utils.Err(err))
@@ -22,10 +19,12 @@ func testUpgradeCLI() {
 		"--client",
 	}
 
-	ginkgo.By("Validating CLI version")
 	out, stderr, err := h.LinkerdRun(cmd...)
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("could not run `linkerd version command`: %s", stderr))
-	gomega.Expect(out).Should(gomega.ContainSubstring(h.GetVersion()), "failed to upgrade CLI")
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("could not run `linkerd version command`: %s", stderr))
+
+	gomega.Expect(out).Should(gomega.ContainSubstring(h.GetVersion()),
+		"failed to upgrade CLI")
 }
 
 func testUpgrade() {
@@ -33,13 +32,14 @@ func testUpgrade() {
 
 	cmd := "upgrade"
 
-	ginkgo.By("Running `linkerd upgrade` command")
 	out, stderr, err := h.LinkerdRun(cmd)
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("`linkerd upgrade` command failed: %s", stderr))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("`linkerd upgrade` command failed: %s", stderr))
 
 	_, err = h.Kubectl(out, "apply", "--prune", "-l", "linkerd.io/control-plane-ns="+h.GetLinkerdNamespace(), "-f", "-")
 
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to apply manifests: %s", utils.Err(err)))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("failed to apply manifests: %s", utils.Err(err)))
 
 	utils.TestControlPlanePostInstall(h)
 	utils.RunCheck(h, false)

--- a/utils/test_helpers.go
+++ b/utils/test_helpers.go
@@ -62,32 +62,30 @@ func RunCheck(h *testutil.TestHelper, pre bool) {
 
 	if pre {
 		cmd = append(cmd, "--pre")
-		ginkgo.By("Running pre-installation checks")
-	} else {
-		ginkgo.By("Running post-installation checks")
 	}
 
 	out, _, _ := h.LinkerdRun(cmd...)
 
-	ginkgo.By("Validating `check` output")
 	err := json.Unmarshal([]byte(out), &checkResult)
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to unmarshal check results JSON: %s", Err(err)))
-	gomega.Expect(checkResult.Success).Should(gomega.BeTrue(), fmt.Sprintf("`linkerd check failed: %s`\n Check errors: %s", Err(err), getFailedChecks(checkResult)))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("failed to unmarshal check results JSON: %s", Err(err)))
+	gomega.Expect(checkResult.Success).Should(gomega.BeTrue(),
+		fmt.Sprintf("`linkerd check failed: %s`\n Check errors: %s",
+			Err(err), getFailedChecks(checkResult)))
 }
 
 // InstallLinkerdControlPlane runs the control plane install tests
 func InstallLinkerdControlPlane(h *testutil.TestHelper, c *ConformanceTestOptions) {
 	withHA := c.HA()
 
-	ginkgo.By(fmt.Sprintf("Installing linkerd control plane with HA: %v", withHA))
 	RunCheck(h, true) // run pre checks
 
 	if err := h.CheckIfNamespaceExists(h.GetLinkerdNamespace()); err == nil {
-		ginkgo.Skip(fmt.Sprintf("linkerd control plane already exists in namespace %s", h.GetLinkerdNamespace()))
+		ginkgo.Skip(fmt.Sprintf("linkerd control plane already exists in namespace %s",
+			h.GetLinkerdNamespace()))
 	}
 
 	// TODO: Uncomment while writing Helm tests
-	// ginkgo.By("verifying if Helm release is empty")
 	// gomega.Expect(h.GetHelmReleaseName()).To(gomega.Equal(""))
 
 	cmd := "install"
@@ -101,13 +99,14 @@ func InstallLinkerdControlPlane(h *testutil.TestHelper, c *ConformanceTestOption
 		addOnFile := "../../addons.yaml"
 		if !fileExists(addOnFile) {
 			out, err := c.GetAddOnsYAML()
-			gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to produce add-on config file: %s", Err(err)))
+			gomega.Expect(err).Should(gomega.BeNil(),
+				fmt.Sprintf("failed to produce add-on config file: %s", Err(err)))
 
 			err = createFileWithContent(out, addOnFile)
-			gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to write add-ons to YAML: %s", Err(err)))
+			gomega.Expect(err).Should(gomega.BeNil(),
+				fmt.Sprintf("failed to write add-ons to YAML: %s", Err(err)))
 		}
 
-		ginkgo.By(fmt.Sprintf("Using add-ons file %s", addOnFile))
 		args = append(args, "--addon-config")
 		args = append(args, addOnFile)
 	}
@@ -122,13 +121,12 @@ func InstallLinkerdControlPlane(h *testutil.TestHelper, c *ConformanceTestOption
 
 	exec := append([]string{cmd}, args...)
 
-	ginkgo.By("Running `linkerd install`")
 	out, stderr, err := h.LinkerdRun(exec...)
 	gomega.Expect(err).Should(gomega.BeNil(), stderr)
 
-	ginkgo.By("Applying control plane manifests")
 	out, err = h.KubectlApply(out, "")
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to apply manifests: %s\n%s", Err(err), out))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("failed to apply manifests: %s\n%s", Err(err), out))
 
 	TestControlPlanePostInstall(h)
 	RunCheck(h, false) // run post checks
@@ -137,7 +135,6 @@ func InstallLinkerdControlPlane(h *testutil.TestHelper, c *ConformanceTestOption
 // UninstallLinkerdControlPlane runs the test for
 // control plane uninstall
 func UninstallLinkerdControlPlane(h *testutil.TestHelper) {
-	ginkgo.By("Uninstalling linkerd control plane")
 	cmd := "install"
 	args := []string{
 		"--ignore-cluster",
@@ -145,27 +142,27 @@ func UninstallLinkerdControlPlane(h *testutil.TestHelper) {
 
 	exec := append([]string{cmd}, args...)
 
-	ginkgo.By("Gathering control plane manifests")
 	out, stderr, err := h.LinkerdRun(exec...)
 	gomega.Expect(err).Should(gomega.BeNil(), stderr)
 
 	args = []string{"delete", "-f", "-"}
 
-	ginkgo.By("Deleting resources from the cluster")
 	out, err = h.Kubectl(out, args...)
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to delete resources: %s\n%s", Err(err), out))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("failed to delete resources: %s\n%s", Err(err), out))
 
 	RunCheck(h, true) // run pre checks
 }
 
 func testResourcesPostInstall(namespace string, services []string, deploys map[string]testutil.DeploySpec, h *testutil.TestHelper) {
-	ginkgo.By(fmt.Sprintf("Checking resources in namespace %s", namespace))
 	err := h.CheckIfNamespaceExists(namespace)
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("could not find namespace %s", namespace))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("could not find namespace %s", namespace))
 
 	for _, svc := range services {
 		err = h.CheckService(namespace, svc)
-		gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("error validating service %s: %s", svc, Err(err)))
+		gomega.Expect(err).Should(gomega.BeNil(),
+			fmt.Sprintf("error validating service %s: %s", svc, Err(err)))
 	}
 
 	for deploy, spec := range deploys {
@@ -177,7 +174,8 @@ func testResourcesPostInstall(namespace string, services []string, deploys map[s
 		}
 
 		err := h.CheckDeployment(namespace, deploy, spec.Replicas)
-		gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("CheckDeployment timed-out for deploy/%s: %s", deploy, Err(err)))
+		gomega.Expect(err).Should(gomega.BeNil(),
+			fmt.Sprintf("CheckDeployment timed-out for deploy/%s: %s", deploy, Err(err)))
 
 	}
 }
@@ -217,40 +215,46 @@ func checkSampleAppState() {
 		}
 
 		err := h.CheckDeployment(emojivotoNs, deploy, 1)
-		gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to validate deploy/%s: %s", deploy, Err(err)))
+		gomega.Expect(err).Should(gomega.BeNil(),
+			fmt.Sprintf("failed to validate deploy/%s: %s", deploy, Err(err)))
 	}
 
 	err := testutil.ExerciseTestAppEndpoint("/api/list", emojivotoNs, h)
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to exercise emojivoto endpoint: %s", Err(err)))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("failed to exercise emojivoto endpoint: %s", Err(err)))
 }
 
 // TestEmojivotoApp installs and checks if emojivoto app is installed
 // called of the function must have `testdata/emojivoto.yml`
 func TestEmojivotoApp() {
-	ginkgo.By("Installing emojivoto")
 	h, _ := GetHelperAndConfig()
 	resources, err := testutil.ReadFile("testdata/emojivoto.yml")
 	gomega.Expect(err).Should(gomega.BeNil(), Err(err))
 
 	_, err = h.KubectlApply(resources, emojivotoNs)
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("could not apply emojivoto manifests to your cluster: %s", Err(err)))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("could not apply emojivoto manifests to your cluster: %s", Err(err)))
+
 	checkSampleAppState()
 }
 
 //TestEmojivotoInject installs and checks if emojivoto app is installed
 // called of the function must have `testdata/emojivoto.yml`
 func TestEmojivotoInject() {
-	ginkgo.By("Injecting emojivoto")
 	h, _ := GetHelperAndConfig()
 
 	out, err := h.Kubectl("", "get", "deploy", "-n", emojivotoNs, "-o", "yaml")
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to get manifests: %s", Err(err)))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("failed to get manifests: %s", Err(err)))
 
 	out, stderr, err := h.PipeToLinkerdRun(out, "inject", "-")
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to inject: %s", stderr))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("failed to inject: %s", stderr))
 
 	out, err = h.KubectlApply(out, emojivotoNs)
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("failed to apply injected resources: %s\n%s", Err(err), out))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("failed to apply injected resources: %s\n%s", Err(err), out))
+
 	checkSampleAppState()
 
 	for _, deploy := range emojivotoDeploys {
@@ -261,11 +265,11 @@ func TestEmojivotoInject() {
 
 // TestEmojivotoUninstall tests if emojivoto can be successfull uninstalled
 func TestEmojivotoUninstall() {
-	ginkgo.By("Uninstalling emojivoto")
 	h, _ := GetHelperAndConfig()
 
 	_, err := h.Kubectl("", "delete", "ns", emojivotoNs)
-	gomega.Expect(err).Should(gomega.BeNil(), fmt.Sprintf("could not delete namespace %s: %s", emojivotoNs, Err(err)))
+	gomega.Expect(err).Should(gomega.BeNil(),
+		fmt.Sprintf("could not delete namespace %s: %s", emojivotoNs, Err(err)))
 }
 
 // CheckProxyContainer gets the pods from a deployment, and checks if the proxy container is present


### PR DESCRIPTION
This PR cleans up the code for lifecycle and inject tests 

- Add line breaks where lines get too long
- Remove unnecessary `ginkgo.By` log messages

Signed-off-by: Mayank Shah <mayankshah1614@gmail.com>